### PR TITLE
fix: resolve all lintr violations in R/ and vignettes/

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvR
 Type: Package
 Title: igvR: integrative genomics viewer
-Version: 1.33.1
+Version: 1.33.2
 Date: 2023-10-09
 Authors@R: c(
     person("Paul", "Shannon", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,15 @@
+CHANGES IN VERSION 1.33.2
+-------------------------
+
+    o Fixed BiocCheck ERRORs/WARNINGs: replaced Author/Maintainer fields with Authors@R [cre],
+      added \value to enableMotifLogoPopups man page, fixed class() == check to use is().
+    o Updated genomeSpec URL from deprecated S3 bucket to https://igv.org/genomes/genomes.json.
+    o Added MotifDb:: and seqLogo:: namespace qualifiers to resolve 'no visible binding' NOTEs.
+    o Replaced full MIT LICENSE text with DCF stub (YEAR/COPYRIGHT HOLDER).
+    o Added GitHub Actions CI workflow (R-CMD-check-bioc, Bioc 3.22, R 4.5).
+    o Added Podman-based local CI (Containerfile, run_local_ci.R, make targets).
+    o Resolved all lintr violations in R/ and vignettes/ (1752 infix_spaces and line_length issues).
+
 CHANGES IN VERSION 1.33.1
 -------------------------
 

--- a/R/BedpeInteractionsTrack.R
+++ b/R/BedpeInteractionsTrack.R
@@ -3,7 +3,7 @@
 #' @exportClass BedpeInteractionsTrack
 
 .BedpeInteractionsTrack <- setClass("BedpeInteractionsTrack",
-                                    contains="DataFrameAnnotationTrack",
+                                    contains = "DataFrameAnnotationTrack",
                                     )
 
 
@@ -21,19 +21,21 @@
 #' @param displayMode  "COLLAPSED", "SQUISHED" or "EXPANDED".  Spelling and case must be precise.
 #' @param table data.frame of 6 or more columns
 #' @param color A css color name (e.g., "red" or "#FF0000"
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A BedpeInteractionsTrack object
 #'
 #' @examples
 #'
-#'     #----------------------------
+#' #----------------------------
 #'     #  first, from a local file
 #'     #----------------------------
 #'
-#'   file <- system.file(package="igvR", "extdata", "sixColumn-demo1.bedpe")
-#'   tbl.bedpe <- read.table(file, sep="\t", as.is=TRUE, header=TRUE)
-#'   dim(tbl.bedpe)  #  32 6
+#'   file <- system.file(package = "igvR", "extdata", "sixColumn-demo1.bedpe")
+#'   tbl.bedpe <- read.table(file, sep = "\t", as.is = TRUE, header = TRUE)
+#'   dim(tbl.bedpe) #  32 6
 #'   track <- BedpeInteractionsTrack("bedpe-6", tbl.bedpe)
 #'
 #'     #------------------------------------------
@@ -41,11 +43,11 @@
 #'     #------------------------------------------
 #'
 #'   shoulder <- 10000
-#'   if(interactive()){
+#'   if (interactive()) {
 #'      igv <- igvR()
 #'      setGenome(igv, "hg38")
 #'      setBrowserWindowTitle(igv, "Paired End Demo")
-#'      roi <- with(tbl.bedpe, sprintf("%s:%d-%d", chrom1[1], min(start1)-shoulder, max(end2) + shoulder))
+#'      roi <- with(tbl.bedpe, sprintf("%s:%d-%d", chrom1[1], min(start1) - shoulder, max(end2) + shoulder))
 #'      showGenomicRegion(igv, roi)
 #'      displayTrack(igv, track)
 #'      }
@@ -53,17 +55,17 @@
 #' @export
 #'
 
-BedpeInteractionsTrack <- function(trackName, table, color="darkBlue",
-                                   trackHeight=50,
-                                   displayMode="EXPANDED",
-                                   visibilityWindow=100000
+BedpeInteractionsTrack <- function(trackName, table, color = "darkBlue",
+                                   trackHeight = 50,
+                                   displayMode = "EXPANDED",
+                                   visibilityWindow = 100000
                                    )
 {
 
    obj <- .BedpeInteractionsTrack(
-                DataFrameAnnotationTrack(trackName, table, color=color,
-                                         displayMode=displayMode, trackHeight=trackHeight,
-                                         visibilityWindow=visibilityWindow)
+                DataFrameAnnotationTrack(trackName, table, color = color,
+                                         displayMode = displayMode, trackHeight = trackHeight,
+                                         visibilityWindow = visibilityWindow)
                                          )
 
 
@@ -84,7 +86,7 @@ BedpeInteractionsTrack <- function(trackName, table, color="darkBlue",
 setMethod("trackSize", "BedpeInteractionsTrack",
 
     function(obj) {
-       if(!is.null(obj@vcf.obj))
+       if (!is.null(obj@vcf.obj))
           return(length(obj@vcf.obj))
        return(NA_integer_)
        })

--- a/R/CramTrack.R
+++ b/R/CramTrack.R
@@ -3,10 +3,10 @@
 #' @exportClass CramTrack
 
 .CramTrack <- setClass("CramTrack",
-                       contains="Track",
-                       slots=c(
-                          cramUrl="character",
-                          indexUrl="character"
+                       contains = "Track",
+                       slots = c(
+                          cramUrl = "character",
+                          indexUrl = "character"
                        ))
 
 #----------------------------------------------------------------------------------------------------
@@ -30,9 +30,9 @@
 CramTrack <- function(trackName,
                       cramUrl,
                       indexUrl,
-                      trackHeight=50,
-                      visibilityWindow=30000,
-                      color="gray")
+                      trackHeight = 50,
+                      visibilityWindow = 30000,
+                      color = "gray")
 {
 
    stopifnot(is.character(trackName) && nchar(trackName) > 0)
@@ -42,18 +42,18 @@ CramTrack <- function(trackName,
    # Note: trackType must be "alignment" for igv.js to use the alignment features
    # but we use "cram" for fileFormat to distinguish it in R dispatch if needed,
    # or rely on the class name.
-   obj <- .CramTrack(Track(trackName=trackName,
-                           trackType="alignment",
-                           fileFormat="cram",
-                           sourceType="url",
-                           color=color,
-                           onScreenOrder=1,
-                           height=trackHeight,
-                           autoTrackHeight=FALSE,
-                           minTrackHeight=50,
-                           maxTrackHeight=500,
-                           visibilityWindow=visibilityWindow),
-                     cramUrl=cramUrl,
-                     indexUrl=indexUrl)
+   obj <- .CramTrack(Track(trackName = trackName,
+                           trackType = "alignment",
+                           fileFormat = "cram",
+                           sourceType = "url",
+                           color = color,
+                           onScreenOrder = 1,
+                           height = trackHeight,
+                           autoTrackHeight = FALSE,
+                           minTrackHeight = 50,
+                           maxTrackHeight = 500,
+                           visibilityWindow = visibilityWindow),
+                     cramUrl = cramUrl,
+                     indexUrl = indexUrl)
    obj
 }

--- a/R/DataFrameAnnotationTrack.R
+++ b/R/DataFrameAnnotationTrack.R
@@ -3,9 +3,9 @@
 #' @exportClass DataFrameAnnotationTrack
 
 .DataFrameAnnotationTrack <- setClass("DataFrameAnnotationTrack",
-                                     contains="igvAnnotationTrack",
-                                     slots=c(
-                                         coreObject="data.frame"
+                                     contains = "igvAnnotationTrack",
+                                     slots = c(
+                                         coreObject = "data.frame"
                                          )
                                      )
 #----------------------------------------------------------------------------------------------------
@@ -20,35 +20,38 @@
 #'
 #' @param trackName  A character string, used as track label by igv, we recommend unique names per track.
 #' @param annotation  A base R \code{data.frame}
-#' @param color A CSS color name (e.g., "red" or "#FF0000"), leave as default empty string if supplying bed9 format with itemRgb.
+#' @param color A CSS color name (e.g., "red" or "#FF0000"), leave as default empty string if supplying
+#'   bed9 format with itemRgb.
 #' @param displayMode "COLLAPSED", "SQUISHED" or "EXPANDED".  Spelling and case must be precise.
 #' @param trackHeight track height, typically in range 20 (for annotations) and up to 1000 (for large sample vcf files)
 #' @param expandedRowHeight  Height of each row of features in "EXPANDED" mode.
 #' @param squishedRowHeight  Height of each row of features in "SQUISHED" mode, for compact viewing.
 #' @param maxRows of features to display
 #' @param searchable  If TRUE, labels on annotation elements may be used in search
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A DataFrameAnnotationTrack object
 #'
 #' @examples
 #' base.loc <- 88883100
-#' tbl <- data.frame(chrom=rep("chr5", 3),
-#'                   start=c(base.loc, base.loc+100, base.loc + 250),
-#'                   end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                   name=c("a", "b", "c"),
-#'                   score=runif(3),
-#'                   strand=rep("*", 3),
-#'                   stringsAsFactors=FALSE)
+#' tbl <- data.frame(chrom = rep("chr5", 3),
+#'                   start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                   end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                   name = c("a", "b", "c"),
+#'                   score = runif(3),
+#'                   strand = rep("*", 3),
+#'                   stringsAsFactors = FALSE)
 #'
 #' track <- DataFrameAnnotationTrack("data.frame demo", tbl)
 #'
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg38")
 #'    setBrowserWindowTitle(igv, "DataFrameAnnotationTrack demo")
 #'    displayTrack(igv, track)
-#'    roi <- sprintf("%s:%d-%d", tbl$chrom[1], min(tbl$start)-100, max(tbl$start) + 100)
+#'    roi <- sprintf("%s:%d-%d", tbl$chrom[1], min(tbl$start) - 100, max(tbl$start) + 100)
 #'    showGenomicRegion(igv, roi)
 #'    Sys.sleep(1)
 #'    zoomOut(igv)
@@ -57,42 +60,42 @@
 #' @export
 #'
 
-DataFrameAnnotationTrack <- function(trackName, annotation, color="", displayMode="SQUISHED",
-                                     trackHeight=50, expandedRowHeight=30, squishedRowHeight=15,
-                                     maxRows=500, searchable=FALSE,
-                                     visibilityWindow=100000)
+DataFrameAnnotationTrack <- function(trackName, annotation, color = "", displayMode = "SQUISHED",
+                                     trackHeight = 50, expandedRowHeight = 30, squishedRowHeight = 15,
+                                     maxRows = 500, searchable = FALSE,
+                                     visibilityWindow = 100000)
 {
      # trackType: annotation, wig, alignment, variant, ga4gh.alignment, alignment.filter, variant.ga4gh
      # sourceType: "file", "gcs" for Google Cloud Storage, and "ga4gh" for the Global Alliance API
      # format: bed, gff, gff3, gtf, bedGraph, wig, vcf, ...
 
-   base.obj <- .igvAnnotationTrack(Track(trackType="annotation",
-                                      sourceType="file",
-                                      fileFormat="bed",
-                                      trackName=trackName,
-                                      onScreenOrder=NA_integer_,
-                                      color=color,
-                                      height=trackHeight,
-                                      autoTrackHeight=FALSE,
-                                      minTrackHeight=50,
-                                      maxTrackHeight=500,
-                                      visibilityWindow=visibilityWindow),
-                                displayMode=displayMode,
-                                expandedRowHeight=expandedRowHeight,
-                                squishedRowHeight=squishedRowHeight,
-                                maxRows=maxRows,
-                                searchable=searchable
+   base.obj <- .igvAnnotationTrack(Track(trackType = "annotation",
+                                      sourceType = "file",
+                                      fileFormat = "bed",
+                                      trackName = trackName,
+                                      onScreenOrder = NA_integer_,
+                                      color = color,
+                                      height = trackHeight,
+                                      autoTrackHeight = FALSE,
+                                      minTrackHeight = 50,
+                                      maxTrackHeight = 500,
+                                      visibilityWindow = visibilityWindow),
+                                displayMode = displayMode,
+                                expandedRowHeight = expandedRowHeight,
+                                squishedRowHeight = squishedRowHeight,
+                                maxRows = maxRows,
+                                searchable = searchable
                                 )
 
    stopifnot("data.frame" %in% is(annotation))
       # if data.frame is bed9 format, with itemRgb column, then if strand is "*", much is lost
-    if(ncol(annotation) >= 9 && "itemRgb"  %in% colnames(annotation)){
-        if("strand" %in% colnames(annotation)){
-           if(!all(annotation$strand %in% c("+", "-")))
+    if (ncol(annotation) >= 9 && "itemRgb" %in% colnames(annotation)) {
+        if ("strand" %in% colnames(annotation)) {
+           if (!all(annotation$strand %in% c("+", "-")))
                warning("bed9 format tables with itemRgb expect only '+' and '-' strand values")
            } # bed9 with strand
        } # bed9+ format
-   obj <- .DataFrameAnnotationTrack(base.obj, coreObject=annotation)
+   obj <- .DataFrameAnnotationTrack(base.obj, coreObject = annotation)
 
 } # DataFrameAnnotationTrack
 #----------------------------------------------------------------------------------------------------
@@ -103,13 +106,13 @@ DataFrameAnnotationTrack <- function(trackName, annotation, color="", displayMod
 #'
 #' @examples
 #' base.loc <- 88883100
-#' tbl <- data.frame(chrom=rep("chr5", 3),
-#'                   start=c(base.loc, base.loc+100, base.loc + 250),
-#'                   end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                   name=c("a", "b", "c"),
-#'                   score=runif(3),
-#'                   strand=rep("*", 3),
-#'                   stringsAsFactors=FALSE)
+#' tbl <- data.frame(chrom = rep("chr5", 3),
+#'                   start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                   end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                   name = c("a", "b", "c"),
+#'                   score = runif(3),
+#'                   strand = rep("*", 3),
+#'                   stringsAsFactors = FALSE)
 #'
 #' track <- DataFrameAnnotationTrack("dataframeTest", tbl)
 #' trackSize(track)
@@ -118,7 +121,7 @@ DataFrameAnnotationTrack <- function(trackName, annotation, color="", displayMod
 #'
 setMethod("trackSize", "DataFrameAnnotationTrack",
 
-    function(obj){
+    function(obj) {
        return(nrow(obj@coreObject))
        })
 

--- a/R/DataFrameQuantitativeTrack.R
+++ b/R/DataFrameQuantitativeTrack.R
@@ -3,9 +3,9 @@
 #' @exportClass DataFrameQuantitativeTrack
 
 .DataFrameQuantitativeTrack <- setClass("DataFrameQuantitativeTrack",
-                                     contains="QuantitativeTrack",
-                                     slots=c(
-                                         coreObject="data.frame"
+                                     contains = "QuantitativeTrack",
+                                     slots = c(
+                                         coreObject = "data.frame"
                                          )
                                      )
 #----------------------------------------------------------------------------------------------------
@@ -25,7 +25,9 @@
 #' @param autoscale Autoscale track to maximum value in view
 #' @param min  Sets the minimum value for the data (y-axis) scale. Usually zero.
 #' @param max  Sets the maximum value for the data (y-axis) scale. This value is ignored if autoscale is TRUE
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @seealso DataFrameAnnotationTrack
 #' @seealso GRangesQuantitativeTrack
@@ -44,27 +46,27 @@
 #'
 #' @examples
 #' base.loc <- 88883100
-#' tbl.blocks <- data.frame(chrom=rep("chr5", 3),
-#'                   start=c(base.loc, base.loc+100, base.loc + 250),
-#'                   end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                   score=runif(3),
-#'                   stringsAsFactors=FALSE)
+#' tbl.blocks <- data.frame(chrom = rep("chr5", 3),
+#'                   start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                   end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                   score = runif(3),
+#'                   stringsAsFactors = FALSE)
 #'
-#' track.blocks <- DataFrameQuantitativeTrack("blocks", tbl.blocks, autoscale=TRUE)
+#' track.blocks <- DataFrameQuantitativeTrack("blocks", tbl.blocks, autoscale = TRUE)
 #'
-#' locs <- seq(from=base.loc, length.out=1000)
-#' tbl.wig <- data.frame(chrom=rep("chr5", 1000), start=locs-1, end=locs,
-#'                       score=runif(n=1000, min=-1, max=1))
-#' track.wig <- DataFrameQuantitativeTrack("wig", tbl.wig, autoscale=FALSE,
-#'                                         min=min(tbl.wig$score), max=max(tbl.wig$score),
-#'                                         color="random")
-#' if(interactive()){
+#' locs <- seq(from = base.loc, length.out = 1000)
+#' tbl.wig <- data.frame(chrom = rep("chr5", 1000), start = locs - 1, end = locs,
+#'                       score = runif(n = 1000, min = -1, max = 1))
+#' track.wig <- DataFrameQuantitativeTrack("wig", tbl.wig, autoscale = FALSE,
+#'                                         min = min(tbl.wig$score), max = max(tbl.wig$score),
+#'                                         color = "random")
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg38")
 #'    setBrowserWindowTitle(igv, "DataFrameQuantitativeTrack demo")
 #'    displayTrack(igv, track.blocks)
 #'    roi <- sprintf("%s:%d-%d", tbl.blocks$chrom[1],
-#'                   min(tbl.blocks$start)-1000, max(tbl.blocks$end) + 1000)
+#'                   min(tbl.blocks$start) - 1000, max(tbl.blocks$end) + 1000)
 #'    showGenomicRegion(igv, roi)
 #'    displayTrack(igv, track.wig)
 #'    }
@@ -72,8 +74,8 @@
 #' @export
 #'
 
-DataFrameQuantitativeTrack <- function(trackName, quantitativeData, color="blue", trackHeight=50,
-                                       autoscale, min=NA_real_, max=NA_real_, visibilityWindow=100000)
+DataFrameQuantitativeTrack <- function(trackName, quantitativeData, color = "blue", trackHeight = 50,
+                                       autoscale, min = NA_real_, max = NA_real_, visibilityWindow = 100000)
 {
    stopifnot(ncol(quantitativeData) >= 4)
 
@@ -82,24 +84,24 @@ DataFrameQuantitativeTrack <- function(trackName, quantitativeData, color="blue"
    stopifnot(is.numeric(quantitativeData[, 3]))
    stopifnot(is.numeric(quantitativeData[, 4]))
 
-   base.obj <- .QuantitativeTrack(Track(trackType="quantitative",
-                                        sourceType="file",
-                                        fileFormat="bedGraph",
-                                        trackName=trackName,
-                                        onScreenOrder=NA_integer_,
-                                        color=color,
-                                        height=trackHeight,
-                                        autoTrackHeight=FALSE,
-                                        minTrackHeight=50,
-                                        maxTrackHeight=500,
-                                        visibilityWindow=visibilityWindow),
-                                  autoscale=autoscale,
-                                  min=min,
-                                  max=max
+   base.obj <- .QuantitativeTrack(Track(trackType = "quantitative",
+                                        sourceType = "file",
+                                        fileFormat = "bedGraph",
+                                        trackName = trackName,
+                                        onScreenOrder = NA_integer_,
+                                        color = color,
+                                        height = trackHeight,
+                                        autoTrackHeight = FALSE,
+                                        minTrackHeight = 50,
+                                        maxTrackHeight = 500,
+                                        visibilityWindow = visibilityWindow),
+                                  autoscale = autoscale,
+                                  min = min,
+                                  max = max
                                   )
 
    stopifnot("data.frame" %in% is(quantitativeData))
-   obj <- .DataFrameQuantitativeTrack(base.obj, coreObject=quantitativeData)
+   obj <- .DataFrameQuantitativeTrack(base.obj, coreObject = quantitativeData)
 
 
 } # DataFrameQuantitativeTrack
@@ -114,7 +116,7 @@ DataFrameQuantitativeTrack <- function(trackName, quantitativeData, color="blue"
 #'
 setMethod("trackSize", "DataFrameQuantitativeTrack",
 
-    function(obj){
+    function(obj) {
        return(nrow(obj@coreObject))
        })
 

--- a/R/GFF3Track.R
+++ b/R/GFF3Track.R
@@ -3,13 +3,13 @@
 #' @exportClass GFF3Track
 
 .GFF3Track <- setClass("GFF3Track",
-                       contains="igvAnnotationTrack",
-                       slots=c(
-                           tbl="data.frame",
-                           url="character",
-                           indexURL="character",
-                           colorByAttribute="character",
-                           colorTable="list"
+                       contains = "igvAnnotationTrack",
+                       slots = c(
+                           tbl = "data.frame",
+                           url = "character",
+                           indexURL = "character",
+                           colorByAttribute = "character",
+                           colorTable = "list"
                            )
                        )
 #----------------------------------------------------------------------------------------------------
@@ -31,13 +31,15 @@
 #' @param colorTable list which maps the colorByAttribute values to different colors
 #' @param displayMode "COLLAPSED", "SQUISHED" or "EXPANDED".  Spelling and case must be precise.
 #' @param trackHeight track height, typically in range 20 (for annotations) and up to 1000 (for large sample vcf files)
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A GFF3Track object
 #'
 #' @examples
-#' tbl.gff3 <- read.table(system.file(package="igvR", "extdata", "GRCh38.94.NDUFS2.gff3"),
-#'                        sep="\t", as.is=TRUE)
+#' tbl.gff3 <- read.table(system.file(package = "igvR", "extdata", "GRCh38.94.NDUFS2.gff3"),
+#'                        sep = "\t", as.is = TRUE)
 #' colnames(tbl.gff3) <- c("seqid", "source", "type", "start", "end", "score", "strand",
 #'                         "phase", "attributes")
 #' colors <- list("antisense" = "blueviolet",
@@ -47,9 +49,9 @@
 #'                "processed_pseudogene" = "#7fff00",
 #'                "unprocessed_pseudogene" = "#d2691e",
 #'                "default" = "black")
-#' track <- GFF3Track("dataframe gff3", tbl.gff3, colorByAttribute="biotype", colorTable=colors,
-#'                    url=NA_character_, indexURL=NA_character_, displayMode="EXPANDED", trackHeight=200,
-#'                    visibilityWindow=100000)
+#' track <- GFF3Track("dataframe gff3", tbl.gff3, colorByAttribute = "biotype", colorTable = colors,
+#'                    url = NA_character_, indexURL = NA_character_, displayMode = "EXPANDED", trackHeight = 200,
+#'                    visibilityWindow = 100000)
 #'
 #'    # gff3 table structure is not bed-like. find chrom, start, end as seen below
 #'
@@ -57,7 +59,7 @@
 #'                               seqid[1],
 #'                               as.integer(min(start)) - 1000,
 #'                               as.integer(max(end)) + 1000))
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg38")
 #'    setBrowserWindowTitle(igv, "GWAS demo")
@@ -67,55 +69,55 @@
 #'
 #' @export
 #'
-GFF3Track <- function(trackName, tbl.track=data.frame(), url=NA_character_, indexURL=NA_character_,
-                      trackColor="black", colorByAttribute=NA_character_, colorTable=list(),
+GFF3Track <- function(trackName, tbl.track = data.frame(), url = NA_character_, indexURL = NA_character_,
+                      trackColor = "black", colorByAttribute = NA_character_, colorTable = list(),
                       displayMode, trackHeight, visibilityWindow)
 {
       # first figure out if the track is defined by immediate data (tbl.track not NA_character_)
       # or remote web-server provided data (url not NA_character_, indexURL optional)
 
-  if(length(colorTable) > 0){
+  if (length(colorTable) > 0) {
      sufficient.info <- TRUE
-     if(is.na(colorByAttribute)){
+     if (is.na(colorByAttribute)) {
          sufficient.info <- FALSE
-     }else if (nchar(colorByAttribute) < 3){
+     } else if (nchar(colorByAttribute) < 3) {
         sufficient.info <- FALSE
         }
-     if(!sufficient.info){
+     if (!sufficient.info) {
          msg <- sprintf("GFF3Track error: colorTable provided, by unusable 'colorByAttribute': %s",
                         colorByAttribute)
          stop(msg)
          } # !sufficient.info
      } # colorTable
 
-   if(length(colorTable) > 0){  # igv.js expects "*" for unspecified track element types
+   if (length(colorTable) > 0) { # igv.js expects "*" for unspecified track element types
       colorTable.default.entry <- grep("default", names(colorTable))
-      if(colorTable.default.entry > 0)
+      if (colorTable.default.entry > 0)
           names(colorTable)[colorTable.default.entry] <- "*"
       }
 
 
 
-   base.obj <- .igvAnnotationTrack(Track(trackType="annotation",
-                                         sourceType="file",
-                                         fileFormat="gff3",
-                                         trackName=trackName,
-                                         onScreenOrder=NA_integer_,
-                                         color=trackColor,
-                                         height=trackHeight,
-                                         autoTrackHeight=FALSE,
-                                         minTrackHeight=50,
-                                         maxTrackHeight=2000,
-                                         visibilityWindow=visibilityWindow),
-                                   displayMode=displayMode,
-                                   expandedRowHeight=30,
-                                   squishedRowHeight=15,
-                                   maxRows=500,
-                                   searchable=FALSE
+   base.obj <- .igvAnnotationTrack(Track(trackType = "annotation",
+                                         sourceType = "file",
+                                         fileFormat = "gff3",
+                                         trackName = trackName,
+                                         onScreenOrder = NA_integer_,
+                                         color = trackColor,
+                                         height = trackHeight,
+                                         autoTrackHeight = FALSE,
+                                         minTrackHeight = 50,
+                                         maxTrackHeight = 2000,
+                                         visibilityWindow = visibilityWindow),
+                                   displayMode = displayMode,
+                                   expandedRowHeight = 30,
+                                   squishedRowHeight = 15,
+                                   maxRows = 500,
+                                   searchable = FALSE
                                    )
 
-   obj <- .GFF3Track(base.obj, tbl=tbl.track, url=url, indexURL=indexURL,
-                     colorByAttribute=colorByAttribute, colorTable=colorTable)
+   obj <- .GFF3Track(base.obj, tbl = tbl.track, url = url, indexURL = indexURL,
+                     colorByAttribute = colorByAttribute, colorTable = colorTable)
 
 
 } # GFF3Track
@@ -129,9 +131,9 @@ GFF3Track <- function(trackName, tbl.track=data.frame(), url=NA_character_, inde
 #'
 setMethod("trackSize", "GFF3Track",
 
-    function(obj){
-       if(is.data.frame(obj@tbl)) return(nrow(obj@tbl))
-       return(NA_integer_)   # we don't know the length of a remote url gff3 table
+    function(obj) {
+       if (is.data.frame(obj@tbl)) return(nrow(obj@tbl))
+       return(NA_integer_) # we don't know the length of a remote url gff3 table
        })
 
 #----------------------------------------------------------------------------------------------------

--- a/R/GRangesAnnotationTrack.R
+++ b/R/GRangesAnnotationTrack.R
@@ -3,9 +3,9 @@
 #' @exportClass GRangesAnnotationTrack
 
 .GRangesAnnotationTrack <- setClass("GRangesAnnotationTrack",
-                                       contains="igvAnnotationTrack",
-                                       slots=c(
-                                          coreObject="GRanges"
+                                       contains = "igvAnnotationTrack",
+                                       slots = c(
+                                          coreObject = "GRanges"
                                           )
                                        )
 #' Constructor for GRangesAnnotationTrack
@@ -26,18 +26,20 @@
 #' @param squishedRowHeight  Height of each row of features in "SQUISHED" mode, for compact viewing.
 #' @param maxRows of features to display
 #' @param searchable  If TRUE, labels on annotation elements may be used in search
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A GRangesAnnotationTrack object
 #'
 #' @examples
 #' base.loc <- 88883100
-#' tbl <- data.frame(chrom=rep("chr5", 3),
-#'                   start=c(base.loc, base.loc+100, base.loc + 250),
-#'                   end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                   name=c("a", "b", "c"),
-#'                   strand=rep("*", 3),
-#'                   stringsAsFactors=FALSE)
+#' tbl <- data.frame(chrom = rep("chr5", 3),
+#'                   start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                   end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                   name = c("a", "b", "c"),
+#'                   strand = rep("*", 3),
+#'                   stringsAsFactors = FALSE)
 #'
 #' gr <- GRanges(tbl)
 #' track <- GRangesAnnotationTrack("GRangesQTest", gr)
@@ -46,32 +48,32 @@
 #'
 
 #----------------------------------------------------------------------------------------------------
-GRangesAnnotationTrack <- function(trackName, annotationData, color="darkGrey", displayMode="SQUISHED",
-                                   trackHeight=50, expandedRowHeight=30, squishedRowHeight=15,
-                                   maxRows=500, searchable=FALSE,
-                                   visibilityWindow=100000)
+GRangesAnnotationTrack <- function(trackName, annotationData, color = "darkGrey", displayMode = "SQUISHED",
+                                   trackHeight = 50, expandedRowHeight = 30, squishedRowHeight = 15,
+                                   maxRows = 500, searchable = FALSE,
+                                   visibilityWindow = 100000)
 {
-   base.obj <- .igvAnnotationTrack(Track(trackType="annotation",
-                                      sourceType="file",
-                                      fileFormat="bed",
-                                      trackName=trackName,
-                                      onScreenOrder=NA_integer_,
-                                      color=color,
-                                      height=trackHeight,
-                                      autoTrackHeight=FALSE,
-                                      minTrackHeight=50,
-                                      maxTrackHeight=500,
-                                      visibilityWindow=visibilityWindow),
-                                displayMode=displayMode,
-                                expandedRowHeight=expandedRowHeight,
-                                squishedRowHeight=squishedRowHeight,
-                                maxRows=maxRows,
-                                searchable=searchable
+   base.obj <- .igvAnnotationTrack(Track(trackType = "annotation",
+                                      sourceType = "file",
+                                      fileFormat = "bed",
+                                      trackName = trackName,
+                                      onScreenOrder = NA_integer_,
+                                      color = color,
+                                      height = trackHeight,
+                                      autoTrackHeight = FALSE,
+                                      minTrackHeight = 50,
+                                      maxTrackHeight = 500,
+                                      visibilityWindow = visibilityWindow),
+                                displayMode = displayMode,
+                                expandedRowHeight = expandedRowHeight,
+                                squishedRowHeight = squishedRowHeight,
+                                maxRows = maxRows,
+                                searchable = searchable
                                 )
 
    stopifnot("GRanges" %in% is(annotationData))
 
-   obj <- .GRangesAnnotationTrack(base.obj, coreObject=annotationData)
+   obj <- .GRangesAnnotationTrack(base.obj, coreObject = annotationData)
 
 } # GRangesAnnotationTrack
 #----------------------------------------------------------------------------------------------------
@@ -85,7 +87,7 @@ GRangesAnnotationTrack <- function(trackName, annotationData, color="darkGrey", 
 #'
 setMethod("trackSize", "GRangesAnnotationTrack",
 
-    function(obj){
+    function(obj) {
        return(length(obj@coreObject))
        })
 

--- a/R/GRangesQuantitativeTrack.R
+++ b/R/GRangesQuantitativeTrack.R
@@ -3,9 +3,9 @@
 #' @exportClass GRangesQuantitativeTrack
 
 .GRangesQuantitativeTrack <- setClass("GRangesQuantitativeTrack",
-                                       contains="QuantitativeTrack",
-                                       slots=c(
-                                          coreObject="GRanges"
+                                       contains = "QuantitativeTrack",
+                                       slots = c(
+                                          coreObject = "GRanges"
                                           )
                                        )
 #' Constructor for GRangesQuantitativeTrack
@@ -24,19 +24,21 @@
 #' @param autoscale  Autoscale track to maximum value in view
 #' @param min   Sets the minimum value for the data (y-axis) scale. Usually zero.
 #' @param max   Sets the maximum value for the data (y-axis) scale. This value is ignored if autoscale is TRUE
-#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A GRangesQuantitativeTrack object
 #'
 #' @examples
 #' base.loc <- 88883100
-#' tbl <- data.frame(chrom=rep("chr5", 3),
-#'                   start=c(base.loc, base.loc+100, base.loc + 250),
-#'                   end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                   name=c("a", "b", "c"),
-#'                   score=runif(3),
-#'                   strand=rep("*", 3),
-#'                   stringsAsFactors=FALSE)
+#' tbl <- data.frame(chrom = rep("chr5", 3),
+#'                   start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                   end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                   name = c("a", "b", "c"),
+#'                   score = runif(3),
+#'                   strand = rep("*", 3),
+#'                   stringsAsFactors = FALSE)
 #'
 #' gr <- GRanges(tbl)
 #' track <- GRangesQuantitativeTrack("GRangesQTest", gr)
@@ -45,27 +47,27 @@
 #'
 
 #----------------------------------------------------------------------------------------------------
-GRangesQuantitativeTrack <- function(trackName, quantitativeData, color="blue", trackHeight=50,
-                                     autoscale=TRUE, min=NA_real_, max=NA_real_, visibilityWindow=100000)
+GRangesQuantitativeTrack <- function(trackName, quantitativeData, color = "blue", trackHeight = 50,
+                                     autoscale = TRUE, min = NA_real_, max = NA_real_, visibilityWindow = 100000)
 {
-   base.obj <- .QuantitativeTrack(Track(trackType="quantitative",
-                                        sourceType="file",
-                                        fileFormat="bedGraph",
-                                        trackName=trackName,
-                                        onScreenOrder=NA_integer_,
-                                        color=color,
-                                        height=trackHeight,
-                                        autoTrackHeight=FALSE,
-                                        minTrackHeight=50,
-                                        maxTrackHeight=500,
-                                        visibilityWindow=visibilityWindow),
-                                  autoscale=autoscale,
-                                  min=min,
-                                  max=max
+   base.obj <- .QuantitativeTrack(Track(trackType = "quantitative",
+                                        sourceType = "file",
+                                        fileFormat = "bedGraph",
+                                        trackName = trackName,
+                                        onScreenOrder = NA_integer_,
+                                        color = color,
+                                        height = trackHeight,
+                                        autoTrackHeight = FALSE,
+                                        minTrackHeight = 50,
+                                        maxTrackHeight = 500,
+                                        visibilityWindow = visibilityWindow),
+                                  autoscale = autoscale,
+                                  min = min,
+                                  max = max
                                   )
 
    stopifnot("GRanges" %in% is(quantitativeData))
-   obj <- .GRangesQuantitativeTrack(base.obj, coreObject=quantitativeData)
+   obj <- .GRangesQuantitativeTrack(base.obj, coreObject = quantitativeData)
 
 } # GRangesQuantitativeTrack
 #----------------------------------------------------------------------------------------------------
@@ -79,7 +81,7 @@ GRangesQuantitativeTrack <- function(trackName, quantitativeData, color="blue", 
 #'
 setMethod("trackSize", "GRangesQuantitativeTrack",
 
-    function(obj){
+    function(obj) {
        return(length(obj@coreObject))
        })
 

--- a/R/GWASTrack.R
+++ b/R/GWASTrack.R
@@ -3,13 +3,13 @@
 #' @exportClass GWASTrack
 
 .GWASTrack <- setClass("GWASTrack",
-                       contains="QuantitativeTrack",
-                       slots=c(
-                           coreObject="data.frame",
-                           chrom.col="numeric",
-                           pos.col="numeric",
-                           pval.col="numeric",
-                           colorTable="list")
+                       contains = "QuantitativeTrack",
+                       slots = c(
+                           coreObject = "data.frame",
+                           chrom.col = "numeric",
+                           pos.col = "numeric",
+                           pval.col = "numeric",
+                           colorTable = "list")
                        )
 
 
@@ -28,7 +28,9 @@
 #' @param pos.col numeric, the column number of the position column
 #' @param pval.col numeric, the column number of the GWAS pvalue colum
 #' @param trackHeight track height, typically in range 20 (for annotations) and up to 1000 (for large sample vcf files)
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #' @param colorTable a named list of CSS colors, by chromosome name - exact matches to
 #'    the names in the GWAS table.
 #' @param autoscale logical, controls how min and max of the y-axis are determined
@@ -38,17 +40,17 @@
 #'
 #' @examples
 #'
-#'   file <- system.file(package="igvR", "extdata", "gwas-5k.tsv")
-#'   tbl.gwas <- read.table(file, sep="\t", header=TRUE, quote="")
+#' file <- system.file(package = "igvR", "extdata", "gwas-5k.tsv")
+#'   tbl.gwas <- read.table(file, sep = "\t", header = TRUE, quote = "")
 #'   dim(tbl.gwas)
-#'   track <- GWASTrack("gwas 5k", tbl.gwas, chrom.col=12, pos.col=13, pval.col=28)
+#'   track <- GWASTrack("gwas 5k", tbl.gwas, chrom.col = 12, pos.col = 13, pval.col = 28)
 #'
-#'   if(interactive()){
+#'   if (interactive()) {
 #'     igv <- igvR()
 #'     setGenome(igv, "hg38")
 #'     setBrowserWindowTitle(igv, "GWAS demo")
 #'     displayTrack(igv, track)
-#'     Sys.sleep(1)  # pause before zooming in
+#'     Sys.sleep(1) # pause before zooming in
 #'     showGenomicRegion(igv, "chr6:32,240,829-32,929,353")
 #'     }
 #'
@@ -60,41 +62,41 @@ GWASTrack <- function(trackName,
                       chrom.col,
                       pos.col,
                       pval.col,
-                      colorTable=list(),
-                      autoscale=TRUE,
-                      min=0,
-                      max=10,
-                      trackHeight=50,
-                      visibilityWindow=100000
+                      colorTable = list(),
+                      autoscale = TRUE,
+                      min = 0,
+                      max = 10,
+                      trackHeight = 50,
+                      visibilityWindow = 100000
                       )
 {
 
     stopifnot(is.data.frame(table))
-    if(length(colorTable) > 0){
+    if (length(colorTable) > 0) {
         chrom.colnames <- unique(table[, chrom.col])
         color.colnames <- names(colorTable)
         unassigned.chroms <- setdiff(chrom.colnames, color.colnames)
-        if(length(unassigned.chroms) > 0){
+        if (length(unassigned.chroms) > 0) {
           msg <- sprintf("one or more chromsomes missing from colorTable: %s",
-                         paste(unassigned.chroms, collapse=", "))
+                         paste(unassigned.chroms, collapse = ", "))
           stop(msg)
           } # if unassigned
         } # if colorTable
 
     obj <- .GWASTrack(QuantitativeTrack(trackName,
-                                        fileFormat="gwas",
-                                        sourceType="file",
+                                        fileFormat = "gwas",
+                                        sourceType = "file",
                                         table,
-                                        trackHeight=trackHeight,
-                                        autoscale=autoscale,
-                                        min=min,
-                                        max=max,
-                                        visibilityWindow=visibilityWindow),
-                      coreObject=table,
-                      chrom.col=chrom.col,
-                      pos.col=pos.col,
-                      pval.col=pval.col,
-                      colorTable=colorTable)
+                                        trackHeight = trackHeight,
+                                        autoscale = autoscale,
+                                        min = min,
+                                        max = max,
+                                        visibilityWindow = visibilityWindow),
+                      coreObject = table,
+                      chrom.col = chrom.col,
+                      pos.col = pos.col,
+                      pval.col = pval.col,
+                      colorTable = colorTable)
 
     obj@trackType <- "gwas"
     obj@fileFormat <- "gwas"
@@ -113,7 +115,7 @@ GWASTrack <- function(trackName,
 setMethod("trackSize", "GWASTrack",
 
     function(obj) {
-       if(!is.null(obj@vcf.obj))
+       if (!is.null(obj@vcf.obj))
           return(length(obj@vcf.obj))
        return(NA_integer_)
        })

--- a/R/GWASUrlTrack.R
+++ b/R/GWASUrlTrack.R
@@ -3,13 +3,13 @@
 #' @exportClass GWASTrack
 
 .GWASUrlTrack <- setClass("GWASUrlTrack",
-                          contains="QuantitativeTrack",
-                          slots=c(
-                              coreObject="character",  # url
-                              chrom.col="numeric",
-                              pos.col="numeric",
-                              pval.col="numeric",
-                              colorTable="list")
+                          contains = "QuantitativeTrack",
+                          slots = c(
+                              coreObject = "character", # url
+                              chrom.col = "numeric",
+                              pos.col = "numeric",
+                              pval.col = "numeric",
+                              colorTable = "list")
                           )
 
 
@@ -28,7 +28,9 @@
 #' @param pos.col numeric, the column number of the position column
 #' @param pval.col numeric, the column number of the GWAS pvalue colum
 #' @param trackHeight track height, typically in range 20 (for annotations) and up to 1000 (for large sample vcf files)
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #' @param colorTable a named list of CSS colors, by chromosome name - exact matches to
 #'    the names in the GWAS table.
 #' @param autoscale logical, controls how min and max of the y-axis are determined
@@ -39,15 +41,15 @@
 #'
 #' @examples
 #'
-#'   track <- GWASUrlTrack("GWAS from url",
+#' track <- GWASUrlTrack("GWAS from url",
 #'                         "https://s3.amazonaws.com/igv.org.demo/gwas_sample.tsv.gz",
-#'                          chrom.col=12, pos.col=13, pval.col=28)
+#'                          chrom.col = 12, pos.col = 13, pval.col = 28)
 #'
 #'     # note: this track is autoscaled.  apparently some infinite values in the file,
 #'     # leading to a flat, low track.  reproduce this in static html, report issue to igv.js
 #'     # temporary workaround: use the interactive track gear to set display range.
 #'
-#' if(interactive()){
+#' if (interactive()) {
 #'     igv <- igvR()
 #'     setGenome(igv, "hg38")
 #'     setBrowserWindowTitle(igv, "GWAS URL demo")
@@ -62,34 +64,34 @@ GWASUrlTrack <- function(trackName,
                          chrom.col,
                          pos.col,
                          pval.col,
-                         colorTable=list(),
-                         autoscale=TRUE,
-                         min=0,
-                         max=10,
-                         trackHeight=50,
-                         visibilityWindow=100000
+                         colorTable = list(),
+                         autoscale = TRUE,
+                         min = 0,
+                         max = 10,
+                         trackHeight = 50,
+                         visibilityWindow = 100000
                          )
 {
 
     stopifnot(is.character(url))
     stopifnot(grepl("http", url))
     obj <- .GWASUrlTrack(
-              QuantitativeTrack(trackName=trackName,
-                                fileFormat="gwas",
-                                sourceType="url",
-                                trackHeight=trackHeight,
-                                #autoTrackHeight=FALSE,
-                                autoscale=autoscale,
-                                min=min,
-                                max=max,
-                                #minTrackHeight=50,
-                                #maxTrackHeight=500,
-                                visibilityWindow=visibilityWindow),
-             coreObject=url,
-             chrom.col=chrom.col,
-             pos.col=pos.col,
-             pval.col=pval.col,
-             colorTable=colorTable)
+              QuantitativeTrack(trackName = trackName,
+                                fileFormat = "gwas",
+                                sourceType = "url",
+                                trackHeight = trackHeight,
+                                # autoTrackHeight=FALSE,
+                                autoscale = autoscale,
+                                min = min,
+                                max = max,
+                                # minTrackHeight=50,
+                                # maxTrackHeight=500,
+                                visibilityWindow = visibilityWindow),
+             coreObject = url,
+             chrom.col = chrom.col,
+             pos.col = pos.col,
+             pval.col = pval.col,
+             colorTable = colorTable)
 
     obj@trackType <- "gwas"
     obj@fileFormat <- "gwas"
@@ -107,7 +109,7 @@ GWASUrlTrack <- function(trackName,
 setMethod("trackSize", "GWASUrlTrack",
 
     function(obj) {
-       if(!is.null(obj@vcf.obj))
+       if (!is.null(obj@vcf.obj))
           return(length(obj@vcf.obj))
        return(NA_integer_)
        })

--- a/R/GenomicAlignmentTrack.R
+++ b/R/GenomicAlignmentTrack.R
@@ -7,9 +7,9 @@
 
 
 .GenomicAlignmentTrack <- setClass("GenomicAlignmentTrack",
-                                 contains="Track",
-                                 slots=c(
-                                    alignment="GAlignments"
+                                 contains = "Track",
+                                 slots = c(
+                                    alignment = "GAlignments"
                                     ))
 
 
@@ -29,16 +29,18 @@
 #' @param trackHeight track height, typically in range 20 (for annotations) and up to 1000 (for large sample vcf files)
 #' @param color A character string, either a reconized color ("red") or a hex string ("#FF8532")
 #'
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A GenomicAlignmentTrack object
 #'
 #' @examples
 #'
-#'   bamFile <- system.file(package="igvR", "extdata", "tumor.bam")
+#' bamFile <- system.file(package = "igvR", "extdata", "tumor.bam")
 #'   which <- GRanges(seqnames = "21", ranges = IRanges(10400126, 10400326))
-#'   param <- ScanBamParam(which=which, what = scanBamWhat())
-#'   x <- readGAlignments(bamFile, use.names=TRUE, param=param)
+#'   param <- ScanBamParam(which = which, what = scanBamWhat())
+#'   x <- readGAlignments(bamFile, use.names = TRUE, param = param)
 #'   track <- GenomicAlignmentTrack("tumor", x)
 #'
 #' @export
@@ -46,24 +48,24 @@
 #----------------------------------------------------------------------------------------------------
 GenomicAlignmentTrack <- function(trackName,
                                   alignment,
-                                  trackHeight=50,
-                                  visibilityWindow=30000,
-                                  color="gray"
+                                  trackHeight = 50,
+                                  visibilityWindow = 30000,
+                                  color = "gray"
                                   )
 {
 
-   obj <- .GenomicAlignmentTrack(Track(trackName=trackName,
-                                       trackType="genomicAlignment",
-                                       fileFormat="bam",
-                                       sourceType="file",
-                                       color=color,
-                                       onScreenOrder=1,
-                                       height=trackHeight,
-                                       autoTrackHeight=FALSE,
-                                       minTrackHeight=50,
-                                       maxTrackHeight=500,
-                                       visibilityWindow=visibilityWindow),
-                        alignment=alignment)
+   obj <- .GenomicAlignmentTrack(Track(trackName = trackName,
+                                       trackType = "genomicAlignment",
+                                       fileFormat = "bam",
+                                       sourceType = "file",
+                                       color = color,
+                                       onScreenOrder = 1,
+                                       height = trackHeight,
+                                       autoTrackHeight = FALSE,
+                                       minTrackHeight = 50,
+                                       maxTrackHeight = 500,
+                                       visibilityWindow = visibilityWindow),
+                        alignment = alignment)
 
    obj
 
@@ -80,7 +82,7 @@ GenomicAlignmentTrack <- function(trackName,
 setMethod("trackSize", "GenomicAlignmentTrack",
 
     function(obj) {
-       if(!is.null(obj@vcf.obj))
+       if (!is.null(obj@vcf.obj))
           return(length(obj@vcf.obj))
        return(NA_integer_)
        })

--- a/R/QuantitativeTrack.R
+++ b/R/QuantitativeTrack.R
@@ -4,11 +4,11 @@
 
 
 .QuantitativeTrack <- setClass("QuantitativeTrack",
-                             contains="Track",
-                             slots=c(
-                                autoscale="logical",
-                                min="numeric",
-                                max="numeric")
+                             contains = "Track",
+                             slots = c(
+                                autoscale = "logical",
+                                min = "numeric",
+                                max = "numeric")
                              )
 
 #----------------------------------------------------------------------------------------------------
@@ -26,43 +26,46 @@
 #' @param quantitativeData  A polyvalent object, either a data.frame, GRanges, or UCSCBedGraphQuantitative object
 #' @param fileFormat only "bedGraph" supported at present; wig and bigWig support soon.
 #' @param color A CSS color name (e.g., "red" or "#FF0000")
-#' @param sourceType only "file" supported at present ("gcs" for Google Cloud Storage, and "ga4gh" for the Global Alliance API may come)
+#' @param sourceType only "file" supported at present ("gcs" for Google Cloud Storage, and "ga4gh" for the
+#'   Global Alliance API may come)
 #' @param trackHeight track height, typically in range 20 (for annotations) and up to 1000 (for large sample vcf files)
 #' @param autoscale  Autoscale track to maximum value in view
 #' @param min   Sets the minimum value for the data (y-axis) scale. Usually zero.
 #' @param max   Sets the maximum value for the data (y-axis) scale. This value is ignored if autoscale is TRUE
-#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A QuantitativeTrack object
 #'
 #' @export
 #'
 QuantitativeTrack <- function(trackName, quantitativeData,
-                              fileFormat=c("wig", "bigWig", "bedGraph", "gwas"),
-                              color="gray",
-                              sourceType=c("file", "url"),
-                              trackHeight=50,
-                              autoscale=TRUE, min=NA_real_, max=NA_real_,
-                              visibilityWindow=100000)
+                              fileFormat = c("wig", "bigWig", "bedGraph", "gwas"),
+                              color = "gray",
+                              sourceType = c("file", "url"),
+                              trackHeight = 50,
+                              autoscale = TRUE, min = NA_real_, max = NA_real_,
+                              visibilityWindow = 100000)
 {
      # trackType: annotation, wig, alignment, variant, ga4gh.alignment, alignment.filter, variant.ga4gh
      # sourceType: "file", "gcs" for Google Cloud Storage, and "ga4gh" for the Global Alliance API
      # format: bed, gff, gff3, gtf, bedGraph, wig, vcf, ...
 
-   obj <- .QuantitativeTrack(Track(trackType="quantitative",
-                                   sourceType=sourceType,
-                                   fileFormat=fileFormat,
-                                   trackName=trackName,
-                                   onScreenOrder=NA_integer_,
-                                   color=color,
-                                   height=trackHeight,
-                                   autoTrackHeight=FALSE,
-                                   minTrackHeight=50,
-                                   maxTrackHeight=500,
-                                   visibilityWindow=visibilityWindow),
-                             autoscale=autoscale,
-                             min=min,
-                             max=max
+   obj <- .QuantitativeTrack(Track(trackType = "quantitative",
+                                   sourceType = sourceType,
+                                   fileFormat = fileFormat,
+                                   trackName = trackName,
+                                   onScreenOrder = NA_integer_,
+                                   color = color,
+                                   height = trackHeight,
+                                   autoTrackHeight = FALSE,
+                                   minTrackHeight = 50,
+                                   maxTrackHeight = 500,
+                                   visibilityWindow = visibilityWindow),
+                             autoscale = autoscale,
+                             min = min,
+                             max = max
                              )
    obj
 
@@ -83,10 +86,10 @@ QuantitativeTrack <- function(trackName, quantitativeData,
 
 setMethod(trackSize, "QuantitativeTrack",
 
-    function(obj){
-       if(!is.null(obj@vcf.obj))
+    function(obj) {
+       if (!is.null(obj@vcf.obj))
           return(length(obj@vcf.obj))
-       return(NA_integer_)    # must be a remote url object, whose size we do not know
+       return(NA_integer_) # must be a remote url object, whose size we do not know
        })
 
 #----------------------------------------------------------------------------------------------------

--- a/R/RemoteAlignmentTrack.R
+++ b/R/RemoteAlignmentTrack.R
@@ -6,9 +6,9 @@
 
 
 .RemoteAlignmentTrack <- setClass("RemoteAlignmentTrack",
-                                 contains="Track",
-                                 slots=c(
-                                    bamUrl="character",
+                                 contains = "Track",
+                                 slots = c(
+                                    bamUrl = "character",
                                     bamIndex = "character"
                                     ))
 
@@ -30,7 +30,9 @@
 #' @param trackHeight track height, typically in range 20 (for annotations) and up to 1000 (for large sample vcf files)
 #' @param color A character string, either a reconized color ("red") or a hex string ("#FF8532")
 #'
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A RemoteAlignmentTrack object
 #'
@@ -41,23 +43,23 @@
 RemoteAlignmentTrack <- function(trackName,
                                  bamUrl,
                                  bamIndex = NULL,
-                                 trackHeight=50,
-                                 visibilityWindow=30000,
-                                 color="gray"
+                                 trackHeight = 50,
+                                 visibilityWindow = 30000,
+                                 color = "gray"
                                  )
 {
-   obj <- .RemoteAlignmentTrack(Track(trackName=trackName,
-                                      trackType="remoteAlignment",
-                                      fileFormat="bam",
-                                      sourceType="url",
-                                      color=color,
-                                      onScreenOrder=1,
-                                      height=trackHeight,
-                                      autoTrackHeight=FALSE,
-                                      minTrackHeight=50,
-                                      maxTrackHeight=500,
-                                      visibilityWindow=visibilityWindow),
-                                bamUrl=bamUrl, bamIndex=bamIndex)
+   obj <- .RemoteAlignmentTrack(Track(trackName = trackName,
+                                      trackType = "remoteAlignment",
+                                      fileFormat = "bam",
+                                      sourceType = "url",
+                                      color = color,
+                                      onScreenOrder = 1,
+                                      height = trackHeight,
+                                      autoTrackHeight = FALSE,
+                                      minTrackHeight = 50,
+                                      maxTrackHeight = 500,
+                                      visibilityWindow = visibilityWindow),
+                                bamUrl = bamUrl, bamIndex = bamIndex)
 
    obj
 

--- a/R/Track.R
+++ b/R/Track.R
@@ -6,23 +6,23 @@
 #' @rdname Track-class
 #' @exportClass Track
 
-.Track <- setClass ("Track",
-                    slots = c(trackType="character",
-                              sourceType="character",
-                              fileFormat="character",
-                              trackName="character",
-                              onScreenOrder="numeric",
-                              color="character",
-                              height="numeric",
-                              autoTrackHeight="logical",
-                              minTrackHeight="numeric",
-                              maxTrackHeight="numeric",
-                              visibilityWindow="numeric")
+.Track <- setClass("Track",
+                    slots = c(trackType = "character",
+                              sourceType = "character",
+                              fileFormat = "character",
+                              trackName = "character",
+                              onScreenOrder = "numeric",
+                              color = "character",
+                              height = "numeric",
+                              autoTrackHeight = "logical",
+                              minTrackHeight = "numeric",
+                              maxTrackHeight = "numeric",
+                              visibilityWindow = "numeric")
                     )
 
 #----------------------------------------------------------------------------------------------------
-setGeneric('trackInfo', signature='obj', function (obj) standardGeneric ('trackInfo'))
-setGeneric('trackSize', signature='obj', function (obj) standardGeneric ('trackSize'))
+setGeneric('trackInfo', signature = 'obj', function(obj) standardGeneric('trackInfo'))
+setGeneric('trackSize', signature = 'obj', function(obj) standardGeneric('trackSize'))
 #----------------------------------------------------------------------------------------------------
 #' Constructor for Track
 #'
@@ -39,18 +39,21 @@ setGeneric('trackSize', signature='obj', function (obj) standardGeneric ('trackS
 #' @param onScreenOrder Numeric, for explicit placement of track within the current set.
 #' @param color A CSS color name (e.g., "red" or "#FF0000")
 #' @param height  track height, typically in range 20 (for annotations) and up to 1000 (for large sample vcf files)
-#' @param autoTrackHeight   If true, then track height is adjusted dynamically, within the bounds set by minHeight and maxHeight, to accomdodate features in view
+#' @param autoTrackHeight   If true, then track height is adjusted dynamically, within the bounds set by
+#'   minHeight and maxHeight, to accomdodate features in view
 #' @param minTrackHeight   In pixels, minimum allowed
 #' @param maxTrackHeight   In pixels, maximum allowed
-#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return An object of class Track
 #'
 #' @export
 #'
-Track <- function(trackType=c("annotation", "quantitative", "alignment", "variant", "gwas"),
-                  sourceType=c("file", "gcs", "ga4gh"),
-                  fileFormat=c("bed",
+Track <- function(trackType = c("annotation", "quantitative", "alignment", "variant", "gwas"),
+                  sourceType = c("file", "gcs", "ga4gh"),
+                  fileFormat = c("bed",
                                "gff", "gff3", "gtf",
                                "wig", "bigWig", "bedGraph",
                                "bam",
@@ -63,22 +66,22 @@ Track <- function(trackType=c("annotation", "quantitative", "alignment", "varian
       # see https://github.com/igvteam/igv.js/wiki/Tracks
    stopifnot(is.character(trackName) && nchar(trackName) > 0)
 
-    if(length(color) == 1){
-       if(color=="random")
+    if (length(color) == 1) {
+       if (color == "random")
           color <- brewer.pal(8, "Dark2")[sample(1:8, 1)]
        }
 
-   obj <- .Track(trackType=trackType,
-                 sourceType=sourceType,
-                 fileFormat=fileFormat,
-                 trackName=trackName,
-                 onScreenOrder=onScreenOrder,
-                 color=color,
-                 height=height,
-                 autoTrackHeight=autoTrackHeight,
-                 minTrackHeight=minTrackHeight,
-                 maxTrackHeight=maxTrackHeight,
-                 visibilityWindow=visibilityWindow)
+   obj <- .Track(trackType = trackType,
+                 sourceType = sourceType,
+                 fileFormat = fileFormat,
+                 trackName = trackName,
+                 onScreenOrder = onScreenOrder,
+                 color = color,
+                 height = height,
+                 autoTrackHeight = autoTrackHeight,
+                 minTrackHeight = minTrackHeight,
+                 maxTrackHeight = maxTrackHeight,
+                 visibilityWindow = visibilityWindow)
 
 } # Track
 #----------------------------------------------------------------------------------------------------
@@ -95,9 +98,9 @@ Track <- function(trackType=c("annotation", "quantitative", "alignment", "varian
 
 setMethod("trackInfo", "Track",
 
-    function(obj){
-       list(trackType=obj@trackType, fileFormat=obj@fileFormat, source=obj@sourceType,
-            class=as.character(class(obj)))
+    function(obj) {
+       list(trackType = obj@trackType, fileFormat = obj@fileFormat, source = obj@sourceType,
+            class = as.character(class(obj)))
         })
 
 #----------------------------------------------------------------------------------------------------

--- a/R/UCSCBedAnnotationTrack.R
+++ b/R/UCSCBedAnnotationTrack.R
@@ -3,9 +3,9 @@
 #' @exportClass UCSCBedAnnotationTrack
 
 .UCSCBedAnnotationTrack <- setClass("UCSCBedAnnotationTrack",
-                                     contains="igvAnnotationTrack",
-                                     slots=c(
-                                         coreObject="UCSCData"
+                                     contains = "igvAnnotationTrack",
+                                     slots = c(
+                                         coreObject = "UCSCData"
                                          )
                                      )
 #----------------------------------------------------------------------------------------------------
@@ -27,7 +27,9 @@
 #' @param squishedRowHeight   Height of each row of features in "SQUISHED" mode, for compact viewing.
 #' @param maxRows  of features to display
 #' @param searchable   If TRUE, labels on annotation elements may be used in search
-#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A UCSCBedAnnotationTrack object
 #'
@@ -35,9 +37,9 @@
 #'
 #' bed.filepath <- system.file(package = "rtracklayer", "tests", "test.bed")
 #' gr.bed <- rtracklayer::import(bed.filepath)
-#' track <- UCSCBedAnnotationTrack("UCSC bed", gr.bed,  color="blue", displayMode="SQUISHED")
+#' track <- UCSCBedAnnotationTrack("UCSC bed", gr.bed, color = "blue", displayMode = "SQUISHED")
 #'
-#' if(interactive()){
+#' if (interactive()) {
 #'     igv <- igvR()
 #'     setGenome(igv, "hg38")
 #'     setBrowserWindowTitle(igv, "UCSC bed10 demo")
@@ -48,35 +50,35 @@
 #' @export
 #'
 
-UCSCBedAnnotationTrack <- function(trackName, annotation, color="darkGrey", displayMode="SQUISHED",
-                                   trackHeight=50,expandedRowHeight=30, squishedRowHeight=15,
-                                   maxRows=500, searchable=FALSE, visibilityWindow=100000)
+UCSCBedAnnotationTrack <- function(trackName, annotation, color = "darkGrey", displayMode = "SQUISHED",
+                                   trackHeight = 50, expandedRowHeight = 30, squishedRowHeight = 15,
+                                   maxRows = 500, searchable = FALSE, visibilityWindow = 100000)
 {
      # trackType: annotation, wig, alignment, variant, ga4gh.alignment, alignment.filter, variant.ga4gh
      # sourceType: "file", "gcs" for Google Cloud Storage, and "ga4gh" for the Global Alliance API
      # format: bed, gff, gff3, gtf, bedGraph, wig, vcf, ...
 
-   base.obj <- .igvAnnotationTrack(Track(trackType="annotation",
-                                      sourceType="file",
-                                      fileFormat="bed",
-                                      trackName=trackName,
-                                      onScreenOrder=NA_integer_,
-                                      color=color,
-                                      height=trackHeight,
-                                      autoTrackHeight=FALSE,
-                                      minTrackHeight=50,
-                                      maxTrackHeight=500,
-                                      visibilityWindow=visibilityWindow),
-                                displayMode=displayMode,
-                                expandedRowHeight=expandedRowHeight,
-                                squishedRowHeight=squishedRowHeight,
-                                maxRows=maxRows,
-                                searchable=searchable
+   base.obj <- .igvAnnotationTrack(Track(trackType = "annotation",
+                                      sourceType = "file",
+                                      fileFormat = "bed",
+                                      trackName = trackName,
+                                      onScreenOrder = NA_integer_,
+                                      color = color,
+                                      height = trackHeight,
+                                      autoTrackHeight = FALSE,
+                                      minTrackHeight = 50,
+                                      maxTrackHeight = 500,
+                                      visibilityWindow = visibilityWindow),
+                                displayMode = displayMode,
+                                expandedRowHeight = expandedRowHeight,
+                                squishedRowHeight = squishedRowHeight,
+                                maxRows = maxRows,
+                                searchable = searchable
                                 )
 
    stopifnot("UCSCData" %in% is(annotation))
    annotation@trackLine@name <- trackName
-   obj <- .UCSCBedAnnotationTrack(base.obj, coreObject=annotation)
+   obj <- .UCSCBedAnnotationTrack(base.obj, coreObject = annotation)
 
 
 } # UCSCBedAnnotationTrack
@@ -90,14 +92,14 @@ UCSCBedAnnotationTrack <- function(trackName, annotation, color="darkGrey", disp
 #' @examples
 #' bed.filepath <- system.file(package = "rtracklayer", "tests", "test.bed")
 #' gr.bed <- rtracklayer::import(bed.filepath)
-#' track.1 <- UCSCBedAnnotationTrack("UCSC bed", gr.bed,  color="blue", displayMode="SQUISHED")
+#' track.1 <- UCSCBedAnnotationTrack("UCSC bed", gr.bed, color = "blue", displayMode = "SQUISHED")
 #' trackSize(track.1)
 #'
 #' @export
 #'
 setMethod("trackSize", "UCSCBedAnnotationTrack",
 
-    function(obj){
+    function(obj) {
        return(length(obj@coreObject))
        })
 

--- a/R/UCSCBedGraphQuantitativeTrack.R
+++ b/R/UCSCBedGraphQuantitativeTrack.R
@@ -4,9 +4,9 @@
 
 
 .UCSCBedGraphQuantitativeTrack <- setClass("UCSCBedGraphQuantitativeTrack",
-                                       contains="QuantitativeTrack",
-                                       slots=c(
-                                          coreObject="UCSCData"
+                                       contains = "QuantitativeTrack",
+                                       slots = c(
+                                          coreObject = "UCSCData"
                                           )
                                        )
 
@@ -27,7 +27,9 @@
 #' @param autoscale  Autoscale track to maximum value in view
 #' @param min   Sets the minimum value for the data (y-axis) scale. Usually zero.
 #' @param max   Sets the maximum value for the data (y-axis) scale. This value is ignored if autoscale is TRUE
-#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A UCSCBedGraphQuantitativeTrack object
 #'
@@ -37,12 +39,12 @@
 #' gr.bedGraph <- rtracklayer::import(bedGraph.filepath)
 #' track <- UCSCBedGraphQuantitativeTrack("UCSCBedGraphTest", gr.bedGraph)
 #'
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg38")
 #'    setBrowserWindowTitle(igv, "UCSC BedGraph demo")
 #'    displayTrack(igv, track)
-#'    Sys.sleep(1)  # pause before zoomin
+#'    Sys.sleep(1) # pause before zoomin
 #'    showGenomicRegion(igv, "chr18:59,103,373-59,105,673")
 #'    }
 #'
@@ -51,27 +53,27 @@
 
 
 #----------------------------------------------------------------------------------------------------
-UCSCBedGraphQuantitativeTrack <- function(trackName, quantitativeData, color="blue", trackHeight=50,
-                                          autoscale=TRUE, min=NA_real_, max=NA_real_, visibilityWindow=100000)
+UCSCBedGraphQuantitativeTrack <- function(trackName, quantitativeData, color = "blue", trackHeight = 50,
+                                          autoscale = TRUE, min = NA_real_, max = NA_real_, visibilityWindow = 100000)
 {
-   base.obj <- .QuantitativeTrack(Track(trackType="quantitative",
-                                        sourceType="file",
-                                        fileFormat="bedGraph",
-                                        trackName=trackName,
-                                        onScreenOrder=NA_integer_,
-                                        color=color,
-                                        height=50,
-                                        autoTrackHeight=FALSE,
-                                        minTrackHeight=50,
-                                        maxTrackHeight=500,
-                                        visibilityWindow=visibilityWindow),
-                                  autoscale=autoscale,
-                                  min=min,
-                                  max=max
+   base.obj <- .QuantitativeTrack(Track(trackType = "quantitative",
+                                        sourceType = "file",
+                                        fileFormat = "bedGraph",
+                                        trackName = trackName,
+                                        onScreenOrder = NA_integer_,
+                                        color = color,
+                                        height = 50,
+                                        autoTrackHeight = FALSE,
+                                        minTrackHeight = 50,
+                                        maxTrackHeight = 500,
+                                        visibilityWindow = visibilityWindow),
+                                  autoscale = autoscale,
+                                  min = min,
+                                  max = max
                                   )
 
    stopifnot(is(quantitativeData, "UCSCData"))
-   obj <- .UCSCBedGraphQuantitativeTrack(base.obj, coreObject=quantitativeData)
+   obj <- .UCSCBedGraphQuantitativeTrack(base.obj, coreObject = quantitativeData)
 
 } # UCSCBedGraphQuantitativeTrack
 #----------------------------------------------------------------------------------------------------
@@ -86,7 +88,7 @@ UCSCBedGraphQuantitativeTrack <- function(trackName, quantitativeData, color="bl
 
 setMethod("trackSize", "UCSCBedGraphQuantitativeTrack",
 
-    function(obj){
+    function(obj) {
        return(length(obj@coreObject))
        })
 

--- a/R/VariantTrack.R
+++ b/R/VariantTrack.R
@@ -2,19 +2,19 @@
 #' @rdname VariantTrack-class
 #' @exportClass VariantTrack
 
-setClassUnion("VCF.or.NULL", members=c("VCF", "NULL"))
+setClassUnion("VCF.or.NULL", members = c("VCF", "NULL"))
 
 
 .VariantTrack <- setClass("VariantTrack",
-                                 contains="Track",
-                                 slots=c(
-                                    displayMode="character",
-                                    vcf.obj="VCF.or.NULL",
-                                    vcf.url="list",
-                                    anchorColor="character",
-                                    homvarColor="character",
-                                    hetvarColor="character",
-                                    homrefColor="character"
+                                 contains = "Track",
+                                 slots = c(
+                                    displayMode = "character",
+                                    vcf.obj = "VCF.or.NULL",
+                                    vcf.url = "list",
+                                    anchorColor = "character",
+                                    homvarColor = "character",
+                                    hetvarColor = "character",
+                                    homrefColor = "character"
                                     )
                                  )
 
@@ -23,7 +23,8 @@ setClassUnion("VCF.or.NULL", members=c("VCF", "NULL"))
 #----------------------------------------------------------------------------------------------------
 #' Constructor for VariantTrack
 #'
-#' \code{VariantTrack} creates an \code{IGV} track for VCF (variant call format) objects, either local or at a remote url
+#' \code{VariantTrack} creates an \code{IGV} track for VCF (variant call format) objects, either local or
+#' at a remote url
 #'
 #' Detailed description goes here
 #'
@@ -38,21 +39,23 @@ setClassUnion("VCF.or.NULL", members=c("VCF", "NULL"))
 #' @param hetvarColor CSS color name for heterzygous variant samples, rgb(34,12,253) by default (~royalBlue)
 #' @param homrefColor CSS color names for homozygous reference samples, rgb(200,200,200) by default (~lightGray)
 #' @param displayMode  "COLLAPSED", "EXPANDED", or "SQUISHED"
-#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return A VariantTrack object
 #'
 #' @examples
 #'
-#'     #----------------------------
+#' #----------------------------
 #'     #  first, from a local file
 #'     #----------------------------
 #'
-#' f <- system.file("extdata", "chr22.vcf.gz", package="VariantAnnotation")
-#' roi <- GRanges(seqnames="22", ranges=IRanges(start=c(50301422, 50989541),
-#'                                               end=c(50312106, 51001328),
-#'                                               names=c("gene_79087", "gene_644186")))
-#' vcf.sub <- VariantAnnotation::readVcf(f, "hg19", param=roi)
+#' f <- system.file("extdata", "chr22.vcf.gz", package = "VariantAnnotation")
+#' roi <- GRanges(seqnames = "22", ranges = IRanges(start = c(50301422, 50989541),
+#'                                               end = c(50312106, 51001328),
+#'                                               names = c("gene_79087", "gene_644186")))
+#' vcf.sub <- VariantAnnotation::readVcf(f, "hg19", param = roi)
 #' track.local <- VariantTrack("chr22-tiny", vcf.sub)
 #'
 #'     #----------------------------
@@ -62,7 +65,7 @@ setClassUnion("VCF.or.NULL", members=c("VCF", "NULL"))
 #' data.url <- sprintf("%s/%s", "https://s3.amazonaws.com/1000genomes/release/20130502",
 #'                                "ALL.wgs.phase3_shapeit2_mvncall_integrated_v5b.20130502.sites.vcf.gz")
 #' index.url <- sprintf("%s.tbi", data.url)
-#' url <- list(data=data.url, index=index.url)
+#' url <- list(data = data.url, index = index.url)
 #'
 #' track.url <- VariantTrack("1kg", url)
 #'
@@ -71,13 +74,13 @@ setClassUnion("VCF.or.NULL", members=c("VCF", "NULL"))
 
 VariantTrack <- function(trackName,
                          vcf,
-                         trackHeight=50,
-                         anchorColor="pink",
-                         homvarColor="rgb(17,248,254)",   # ~turquoise
-                         hetvarColor="rgb(34,12,253)",    # ~royalBlue
-                         homrefColor="rgb(200,200,200)",  # ~lightGray
-                         displayMode="EXPANDED",
-                         visibilityWindow=100000
+                         trackHeight = 50,
+                         anchorColor = "pink",
+                         homvarColor = "rgb(17,248,254)", # ~turquoise
+                         hetvarColor = "rgb(34,12,253)", # ~royalBlue
+                         homrefColor = "rgb(200,200,200)", # ~lightGray
+                         displayMode = "EXPANDED",
+                         visibilityWindow = 100000
                          )
 {
 
@@ -85,39 +88,39 @@ VariantTrack <- function(trackName,
       # or it me be a url to a hosted vcf file on a (typically public) webserver.
       # we determine this crucial difference first
 
-   vcf.object.classes <- is(vcf)   # "is" reports multiple classes, from the class hierarchy
+   vcf.object.classes <- is(vcf) # "is" reports multiple classes, from the class hierarchy
    vcf.obj <- NULL
    vcf.url <- list()
 
-   if("VCF" %in% vcf.object.classes)
+   if ("VCF" %in% vcf.object.classes)
       vcf.obj <- vcf
 
-   if("list" %in% vcf.object.classes) {
-      if(all(sort(names(vcf) == c("data", "index"))))
+   if ("list" %in% vcf.object.classes) {
+      if (all(sort(names(vcf) == c("data", "index"))))
          vcf.url <- vcf
       }
 
-   if(is.null(vcf.obj) & length(vcf.url) == 0){
+   if (is.null(vcf.obj) & length(vcf.url) == 0) {
       stop("vcf argument neither a VCF nor a list or data & index urls")
       }
 
-   obj <- .VariantTrack(Track(trackName=trackName,
-                              trackType="variant",
-                              color=anchorColor,
-                              fileFormat="vcf",
-                              sourceType="file",
-                              onScreenOrder=1,
-                              height=trackHeight,
-                              autoTrackHeight=FALSE,
-                              minTrackHeight=50,
-                              maxTrackHeight=500,
-                              visibilityWindow=visibilityWindow),
-                        displayMode=displayMode,
-                        vcf.obj=vcf.obj,
-                        vcf.url=vcf.url,
-                        homvarColor=homvarColor,
-                        hetvarColor=hetvarColor,
-                        homrefColor=homrefColor)
+   obj <- .VariantTrack(Track(trackName = trackName,
+                              trackType = "variant",
+                              color = anchorColor,
+                              fileFormat = "vcf",
+                              sourceType = "file",
+                              onScreenOrder = 1,
+                              height = trackHeight,
+                              autoTrackHeight = FALSE,
+                              minTrackHeight = 50,
+                              maxTrackHeight = 500,
+                              visibilityWindow = visibilityWindow),
+                        displayMode = displayMode,
+                        vcf.obj = vcf.obj,
+                        vcf.url = vcf.url,
+                        homvarColor = homvarColor,
+                        hetvarColor = hetvarColor,
+                        homrefColor = homrefColor)
 
    obj
 
@@ -134,7 +137,7 @@ VariantTrack <- function(trackName,
 setMethod("trackSize", "VariantTrack",
 
     function(obj) {
-       if(!is.null(obj@vcf.obj))
+       if (!is.null(obj@vcf.obj))
           return(length(obj@vcf.obj))
        return(NA_integer_)
        })

--- a/R/genomeSpec.R
+++ b/R/genomeSpec.R
@@ -34,17 +34,17 @@ url.exists <- function(url)
 #' @return an list of short genome codes, e.g., "hg38", "dm6", "tair10"
 #' @export
 #'
-currently.supported.stock.genomes <- function(test=FALSE)
+currently.supported.stock.genomes <- function(test = FALSE)
 {
-    basic.offerings <-  c("hg38", "hg19", "mm10", "tair10", "rhos", "custom", "dm6", "sacCer3")
-    if(test) return(basic.offerings)
+    basic.offerings <- c("hg38", "hg19", "mm10", "tair10", "rhos", "custom", "dm6", "sacCer3")
+    if (test) return(basic.offerings)
 
     current.genomes.file <- "https://igv.org/genomes/genomes.json"
 
-    if(!url.exists(current.genomes.file))
+    if (!url.exists(current.genomes.file))
         return(basic.offerings)
 
-    current.genomes.raw <- readLines(current.genomes.file, warn=FALSE, skipNul=TRUE)
+    current.genomes.raw <- readLines(current.genomes.file, warn = FALSE, skipNul = TRUE)
     tbl.genomes <- fromJSON(current.genomes.raw)
     tbl.genomes$id
 
@@ -69,28 +69,28 @@ currently.supported.stock.genomes <- function(test=FALSE)
 #'    to a genome annotation file in a gff3 format
 #'
 #' @examples
-#' genomeSpec <- parseAndValidateGenomeSpec("hg38", "APOE")  # the simplest case
+#' genomeSpec <- parseAndValidateGenomeSpec("hg38", "APOE") # the simplest case
 #' base.url <- "https://gladki.pl/igvr/testFiles/sarsGenome"
-#' fasta.file <- sprintf("%s/%s", base.url,"Sars_cov_2.ASM985889v3.dna.toplevel.fa")
-#' fastaIndex.file <-  sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.dna.toplevel.fa.fai")
-#' annotation.file <-  sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.101.gff3")
+#' fasta.file <- sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.dna.toplevel.fa")
+#' fastaIndex.file <- sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.dna.toplevel.fa.fai")
+#' annotation.file <- sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.101.gff3")
 #' custom.genome.title <- "SARS-CoV-2"
-#' genomeOptions <- parseAndValidateGenomeSpec(genomeName=custom.genome.title,
-#'                                             initialLocus="all",
-#'                                             stockGenome=FALSE,
-#'                                             dataMode="http",
-#'                                             fasta=fasta.file,
-#'                                             fastaIndex=fastaIndex.file,
-#'                                             genomeAnnotation=annotation.file)
+#' genomeOptions <- parseAndValidateGenomeSpec(genomeName = custom.genome.title,
+#'                                             initialLocus = "all",
+#'                                             stockGenome = FALSE,
+#'                                             dataMode = "http",
+#'                                             fasta = fasta.file,
+#'                                             fastaIndex = fastaIndex.file,
+#'                                             genomeAnnotation = annotation.file)
 #'
 #' @seealso [currently.supported.stock.genomes()] for stock genomes we support.
 #'
 #' @return an options list directly usable by igvApp.js, and thus igv.js
 #' @export
 #'
-parseAndValidateGenomeSpec <- function(genomeName, initialLocus="all",
-                                       stockGenome=TRUE,
-                                       dataMode=NA, fasta=NA, fastaIndex=NA, genomeAnnotation=NA)
+parseAndValidateGenomeSpec <- function(genomeName, initialLocus = "all",
+                                       stockGenome = TRUE,
+                                       dataMode = NA, fasta = NA, fastaIndex = NA, genomeAnnotation = NA)
 {
     options <- list()
     options[["stockGenome"]] <- stockGenome
@@ -102,11 +102,11 @@ parseAndValidateGenomeSpec <- function(genomeName, initialLocus="all",
     # only check if the genomeName is recognized
     #--------------------------------------------------
 
-    if(stockGenome){
+    if (stockGenome) {
        supported.stock.genomes <- currently.supported.stock.genomes()
-       if(!genomeName %in% supported.stock.genomes){
+       if (!genomeName %in% supported.stock.genomes) {
           s.1 <- sprintf("Your genome '%s' is not currently supported", genomeName)
-          s.2 <- sprintf("Currently supported: %s", paste(supported.stock.genomes, collapse=","))
+          s.2 <- sprintf("Currently supported: %s", paste(supported.stock.genomes, collapse = ","))
           msg <- sprintf("%s\n%s", s.1, s.2)
           stop(msg)
           }
@@ -116,17 +116,17 @@ parseAndValidateGenomeSpec <- function(genomeName, initialLocus="all",
        options[["fastaIndex"]] <- NA
        options[["annotation"]] <- NA
        options[["validated"]] <- TRUE
-       }# stockGenome requested
+       } # stockGenome requested
 
-    if(!stockGenome){
+    if (!stockGenome) {
        stopifnot(!is.na(dataMode))
        stopifnot(!is.na(fasta))
        stopifnot(!is.na(fastaIndex))
          # genomeAnnotation is optional
 
-       recognized.modes <- c("localFiles", "http")  # "direct" for an in-memory R data structure, deferred
-       if(!dataMode %in% recognized.modes){
-          msg <- sprintf("dataMode '%s' should be one of %s", dataMode, paste(recognized.modes, collapse=","))
+       recognized.modes <- c("localFiles", "http") # "direct" for an in-memory R data structure, deferred
+       if (!dataMode %in% recognized.modes) {
+          msg <- sprintf("dataMode '%s' should be one of %s", dataMode, paste(recognized.modes, collapse = ","))
           stop(msg)
           }
        #---------------------------------------------------------------------
@@ -139,10 +139,10 @@ parseAndValidateGenomeSpec <- function(genomeName, initialLocus="all",
                                  )
        stopifnot(exists.function(fasta))
        stopifnot(exists.function(fastaIndex))
-       if(!is.na(genomeAnnotation))
+       if (!is.na(genomeAnnotation))
           stopifnot(exists.function(genomeAnnotation))
 
-       options[["genomeName"]]  <- genomeName
+       options[["genomeName"]] <- genomeName
        options[["fasta"]] <- fasta
        options[["fastaIndex"]] <- fastaIndex
        options[["initialLocus"]] <- initialLocus

--- a/R/igvAnnotationTrack.R
+++ b/R/igvAnnotationTrack.R
@@ -3,15 +3,15 @@
 #' @exportClass igvAnnotationTrack
 
 .igvAnnotationTrack <- setClass("igvAnnotationTrack",
-                             contains="Track",
-                             slots=c(
-                                classTypeOfSuppliedObject="character",
-                                displayMode="character",
-                                expandedRowHeight="numeric",
-                                squishedRowHeight="numeric",
-                                nameField="character",
-                                maxRows="numeric",
-                                searchable="logical")
+                             contains = "Track",
+                             slots = c(
+                                classTypeOfSuppliedObject = "character",
+                                displayMode = "character",
+                                expandedRowHeight = "numeric",
+                                squishedRowHeight = "numeric",
+                                nameField = "character",
+                                maxRows = "numeric",
+                                searchable = "logical")
                              )
 
 #----------------------------------------------------------------------------------------------------
@@ -31,19 +31,21 @@
 #' @param squishedRowHeight  Height of each row of features in "SQUISHED" mode, for compact viewing.
 #' @param maxRows of features to display
 #' @param searchable  If TRUE, labels on annotation elements may be used in search
-#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other track types.
+#' @param visibilityWindow  Maximum window size in base pairs for which indexed annotations
+#'   or variants are displayed. Defaults: 1 MB for variants, whole chromosome for other
+#'   track types.
 #'
 #' @return An igvAnnotationTrack object
 
 igvAnnotationTrack <- function(trackName, annotation,
-                            fileFormat=c("bed"),   # to be added:  "gff", "gff3", "gtf"
-                            color="gray",
-                            displayMode=c("SQUISHED", "COLLAPSED", "EXPANDED"),
-                            sourceType="file",
-                            trackHeight=30,
-                            expandedRowHeight=30, squishedRowHeight=15,
-                            maxRows=500, searchable=FALSE,
-                            visibilityWindow=100000)
+                            fileFormat = c("bed"), # to be added:  "gff", "gff3", "gtf"
+                            color = "gray",
+                            displayMode = c("SQUISHED", "COLLAPSED", "EXPANDED"),
+                            sourceType = "file",
+                            trackHeight = 30,
+                            expandedRowHeight = 30, squishedRowHeight = 15,
+                            maxRows = 500, searchable = FALSE,
+                            visibilityWindow = 100000)
 {
      # trackType: annotation, wig, alignment, variant, ga4gh.alignment, alignment.filter, variant.ga4gh
      # sourceType: "file", "gcs" for Google Cloud Storage, and "ga4gh" for the Global Alliance API
@@ -52,23 +54,23 @@ igvAnnotationTrack <- function(trackName, annotation,
    annotation.obj.class <- class(annotation)
    stopifnot(annotation.obj.class %in% c("data.frame", "UCSCData"))
 
-   obj <- .igvAnnotationTrack(Track(trackType="annotation",
-                                 sourceType=sourceType,
-                                 fileFormat=fileFormat,
-                                 trackName=trackName,
-                                 onScreenOrder=NA_integer_,
-                                 color=color,
-                                 height=trackHeight,
-                                 autoTrackHeight=FALSE,
-                                 minTrackHeight=50,
-                                 maxTrackHeight=500,
-                                 visibilityWindow=visibilityWindow),
-                           displayMode=match.arg(displayMode),
-                           expandedRowHeight=expandedRowHeight,
-                           squishedRowHeight=squishedRowHeight,
-                           maxRows=maxRows,
-                           searchable=searchable,
-                           classTypeOfSuppliedObject=annotation.obj.class
+   obj <- .igvAnnotationTrack(Track(trackType = "annotation",
+                                 sourceType = sourceType,
+                                 fileFormat = fileFormat,
+                                 trackName = trackName,
+                                 onScreenOrder = NA_integer_,
+                                 color = color,
+                                 height = trackHeight,
+                                 autoTrackHeight = FALSE,
+                                 minTrackHeight = 50,
+                                 maxTrackHeight = 500,
+                                 visibilityWindow = visibilityWindow),
+                           displayMode = match.arg(displayMode),
+                           expandedRowHeight = expandedRowHeight,
+                           squishedRowHeight = squishedRowHeight,
+                           maxRows = maxRows,
+                           searchable = searchable,
+                           classTypeOfSuppliedObject = annotation.obj.class
                            )
    obj
 

--- a/R/igvR.R
+++ b/R/igvR.R
@@ -12,49 +12,52 @@
 #' @rdname igvR-class
 #' @exportClass igvR
 
-.igvR <- setClass ("igvR",
-                  representation = representation (),
+.igvR <- setClass("igvR",
+                  representation = representation(),
                   contains = "BrowserViz",
-                     prototype = prototype (uri="http://localhost", 9000)
+                     prototype = prototype(uri = "http://localhost", 9000)
                     )
 
 
 #----------------------------------------------------------------------------------------------------
 igvBrowserFile <- NULL
 
-.onLoad <- function(...){
-   igvBrowserFile <<- system.file(package="igvR", "browserCode", "dist", "igvApp.html")
+.onLoad <- function(...) {
+   igvBrowserFile <<- system.file(package = "igvR", "browserCode", "dist", "igvApp.html")
    }
 
 #----------------------------------------------------------------------------------------------------
-setGeneric('ping',                  signature='obj', function(obj, msecDelay=0) standardGeneric ('ping'))
-setGeneric('setGenome',             signature='obj', function(obj, genomeName) standardGeneric ('setGenome'))
-setGeneric('setCustomGenome',       signature='obj', function(obj,
+setGeneric('ping', signature = 'obj', function(obj, msecDelay = 0) standardGeneric('ping'))
+setGeneric('setGenome', signature = 'obj', function(obj, genomeName) standardGeneric('setGenome'))
+setGeneric('setCustomGenome', signature = 'obj', function(obj,
                                                               id,
                                                               genomeName,
                                                               fastaURL,
                                                               fastaIndexURL,
-                                                              chromosomeAliasURL=NA,
-                                                              cytobandURL=NA,
-                                                              geneAnnotationName=NA,
-                                                              geneAnnotationURL=NA,
-                                                              geneAnnotationTrackHeight=200,
-                                                              geneAnnotationTrackColor="darkblue",
-                                                              initialLocus="all",
-                                                              visibilityWindow=1000000) standardGeneric ('setCustomGenome'))
-setGeneric('getSupportedGenomes',   signature='obj', function(obj) standardGeneric ('getSupportedGenomes'))
-setGeneric('getGenomicRegion',      signature='obj', function(obj) standardGeneric('getGenomicRegion'))
-setGeneric('showGenomicRegion',     signature='obj', function(obj, region)  standardGeneric('showGenomicRegion'))
-setGeneric('zoomOut',               signature='obj', function(obj) standardGeneric('zoomOut'))
-setGeneric('zoomIn',                signature='obj', function(obj) standardGeneric('zoomIn'))
-setGeneric('setTrackClickFunction', signature='obj', function(obj, javascriptFunction) standardGeneric('setTrackClickFunction'))
-setGeneric('displayTrack',          signature='obj', function(obj, track, deleteTracksOfSameName=TRUE) standardGeneric('displayTrack'))
-setGeneric('showTrackLabels',       signature='obj', function(obj, newState) standardGeneric('showTrackLabels'))
-setGeneric('getTrackNames',         signature='obj', function(obj) standardGeneric('getTrackNames'))
-setGeneric('removeTracksByName',    signature='obj', function(obj, trackNames) standardGeneric('removeTracksByName'))
-setGeneric('setTrackHeight',        signature='obj', function(obj, trackName, newHeight) standardGeneric('setTrackHeight'))
-setGeneric('saveToSVG',             signature='obj', function(obj, filename) standardGeneric('saveToSVG'))
-setGeneric('enableMotifLogoPopups', signature='obj', function(obj, status) standardGeneric('enableMotifLogoPopups'))
+                                                              chromosomeAliasURL = NA,
+                                                              cytobandURL = NA,
+                                                              geneAnnotationName = NA,
+                                                              geneAnnotationURL = NA,
+                                                              geneAnnotationTrackHeight = 200,
+                                                              geneAnnotationTrackColor = "darkblue",
+                                                              initialLocus = "all",
+                                                              visibilityWindow = 1000000)
+                                                              standardGeneric('setCustomGenome'))
+setGeneric('getSupportedGenomes', signature = 'obj', function(obj) standardGeneric('getSupportedGenomes'))
+setGeneric('getGenomicRegion', signature = 'obj', function(obj) standardGeneric('getGenomicRegion'))
+setGeneric('showGenomicRegion', signature = 'obj', function(obj, region) standardGeneric('showGenomicRegion'))
+setGeneric('zoomOut', signature = 'obj', function(obj) standardGeneric('zoomOut'))
+setGeneric('zoomIn', signature = 'obj', function(obj) standardGeneric('zoomIn'))
+setGeneric('setTrackClickFunction', signature = 'obj',
+           function(obj, javascriptFunction) standardGeneric('setTrackClickFunction'))
+setGeneric('displayTrack', signature = 'obj',
+           function(obj, track, deleteTracksOfSameName = TRUE) standardGeneric('displayTrack'))
+setGeneric('showTrackLabels', signature = 'obj', function(obj, newState) standardGeneric('showTrackLabels'))
+setGeneric('getTrackNames', signature = 'obj', function(obj) standardGeneric('getTrackNames'))
+setGeneric('removeTracksByName', signature = 'obj', function(obj, trackNames) standardGeneric('removeTracksByName'))
+setGeneric('setTrackHeight', signature = 'obj', function(obj, trackName, newHeight) standardGeneric('setTrackHeight'))
+setGeneric('saveToSVG', signature = 'obj', function(obj, filename) standardGeneric('saveToSVG'))
+setGeneric('enableMotifLogoPopups', signature = 'obj', function(obj, status) standardGeneric('enableMotifLogoPopups'))
 #----------------------------------------------------------------------------------------------------
 setupMessageHandlers <- function()
 {
@@ -83,37 +86,37 @@ setupMessageHandlers <- function()
 #' @export
 #'
 #' @examples
-#' if(interactive()){
-#'    igv <- igvR(title="igv demo")
+#' if (interactive()) {
+#'    igv <- igvR(title = "igv demo")
 #'    setGenome(igv, "hg38")
 #'    showGenomicRegion(igv, "MEF2C")
 #'      #---------------------------------------------------------------
 #'      # an easy transparent way to create a bed track
 #'      #---------------------------------------------------------------
 #'    base.loc <- 88883100
-#'    tbl <- data.frame(chrom=rep("chr5", 3),
-#'                      start=c(base.loc, base.loc+100, base.loc + 250),
-#'                      end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                      name=c("a", "b", "c"),
-#'                      score=runif(3),
-#'                      strand=rep("*", 3),
-#'                      stringsAsFactors=FALSE)
+#'    tbl <- data.frame(chrom = rep("chr5", 3),
+#'                      start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                      end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                      name = c("a", "b", "c"),
+#'                      score = runif(3),
+#'                      strand = rep("*", 3),
+#'                      stringsAsFactors = FALSE)
 #'
-#'    track <- DataFrameAnnotationTrack("dataframeTest", tbl, color="red", displayMode="EXPANDED")
+#'    track <- DataFrameAnnotationTrack("dataframeTest", tbl, color = "red", displayMode = "EXPANDED")
 #'    displayTrack(igv, track)
-#'    showGenomicRegion(igv, sprintf("chr5:%d-%d", base.loc-100, base.loc+350))
+#'    showGenomicRegion(igv, sprintf("chr5:%d-%d", base.loc - 100, base.loc + 350))
 #'    } # if interactive
 #'
-#----------------------------------------------------------------------------------------------------
-igvR = function(portRange=15000:15100, host="localhost", title="igvR", browserFile=igvBrowserFile,
-                quiet=TRUE)
+#' #---------------------------------------------------------------------------------------------------
+igvR = function(portRange = 15000:15100, host = "localhost", title = "igvR", browserFile = igvBrowserFile,
+                quiet = TRUE)
 {
-   if(!quiet){
+   if (!quiet) {
       message(sprintf("want to load %s", igvBrowserFile))
       }
 
-   obj <- .igvR(BrowserViz(host, portRange, title, browserFile=browserFile, quiet,
-                           httpQueryProcessingFunction=myQP))
+   obj <- .igvR(BrowserViz(host, portRange, title, browserFile = browserFile, quiet,
+                           httpQueryProcessingFunction = myQP))
    setBrowserWindowTitle(obj, title)
 
    obj
@@ -133,16 +136,15 @@ igvR = function(portRange=15000:15100, host="localhost", title="igvR", browserFi
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    ping(igv)
 #'    }
-
 setMethod('ping', 'igvR',
 
-  function (obj, msecDelay=0) {
-     send(obj, list(cmd="ping", callback="handleResponse", status="request", payload=msecDelay))
-     while (!browserResponseReady(obj)){
+  function(obj, msecDelay = 0) {
+     send(obj, list(cmd = "ping", callback = "handleResponse", status = "request", payload = msecDelay))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      getBrowserResponse(obj)
@@ -165,7 +167,7 @@ setMethod('ping', 'igvR',
 #'
 #' @examples
 #'
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    ping(igv)
 #'    }
@@ -189,23 +191,23 @@ url.exists <- function(url)
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "mm10")
 #'    }
 #'
 setMethod('setGenome', 'igvR',
 
-  function (obj, genomeName) {
+  function(obj, genomeName) {
      BrowserViz:::log("igvR::setGenome")
      stopifnot(genomeName %in% getSupportedGenomes(obj))
 
      payload <- genomeName
-     send(obj, list(cmd="setGenome", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+     send(obj, list(cmd = "setGenome", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
-     #enableMotifLogoPopups(obj, TRUE)
+     # enableMotifLogoPopups(obj, TRUE)
      invisible(getBrowserResponse(obj));
      })
 
@@ -219,11 +221,15 @@ setMethod('setGenome', 'igvR',
 #' @param id character string, a short name, displayed in the browser, e.g., "hg38", "tair10".
 #' @param genomeName character string, possibly longer, more descirptive then the id, e.g., "Human (GRCh38/hg38)"
 #' @param fastaURL character string, e.g."https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa"
-#' @param fastaIndexURL character string, e.g. "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa.fai"
-#' @param chromosomeAliasURL character string, default NA, a tab-delimited file supporting multiple equivalent chromosome names. see details
-#' @param cytobandURL character string, default NA, a cytoband ideogram file in UCSC format, e.g. "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/cytoBandIdeo.txt"
+#' @param fastaIndexURL character string, e.g.
+#'   "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa.fai"
+#' @param chromosomeAliasURL character string, default NA, a tab-delimited file supporting multiple
+#'   equivalent chromosome names. see details
+#' @param cytobandURL character string, default NA, a cytoband ideogram file in UCSC format, e.g.
+#'   "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/cytoBandIdeo.txt"
 #' @param geneAnnotationName character string, e.g. "Refseq Genes", default NA
-#' @param geneAnnotationURL character string, e.g. "https://s3.amazonaws.com/igv.org.genomes/hg38/refGene.txt.gz", default NA
+#' @param geneAnnotationURL character string, e.g.
+#'   "https://s3.amazonaws.com/igv.org.genomes/hg38/refGene.txt.gz", default NA
 #' @param geneAnnotationTrackHeight numeric, pixels, e.g. 500.  default 200
 #' @param geneAnnotationTrackColor character string, any legal CSS color, default "darkblue"
 #' @param initialLocus character string, e.g. "chr5:88,621,308-89,001,037" or "MEF2C"
@@ -234,55 +240,54 @@ setMethod('setGenome', 'igvR',
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setCustomGenome(igv,
-#'                    id="hg38",
-#'                    genomeName="Human (GRCh38/hg38)",
-#'                    fastaURL="https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa",
-#'                    fastaIndexURL="https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa.fai",
-#'                    chromosomeAliasURL=NA,
-#'                    cytobandURL="https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/cytoBandIdeo.txt",
-#'                    geneAnnotationName="Refseq Genes",
-#'                    geneAnnotationURL="https://s3.amazonaws.com/igv.org.genomes/hg38/refGene.txt.gz",
-#'                    geneAnnotationTrackHeight=300,
-#'                    geneAnnotationTrackColor="darkgreen",
-#'                    initialLocus="chr5:88,621,308-89,001,037",
-#'                    visibilityWindow=5000000)
+#'                    id = "hg38",
+#'                    genomeName = "Human (GRCh38/hg38)",
+#'                    fastaURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa",
+#'                    fastaIndexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa.fai",
+#'                    chromosomeAliasURL = NA,
+#'                    cytobandURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/cytoBandIdeo.txt",
+#'                    geneAnnotationName = "Refseq Genes",
+#'                    geneAnnotationURL = "https://s3.amazonaws.com/igv.org.genomes/hg38/refGene.txt.gz",
+#'                    geneAnnotationTrackHeight = 300,
+#'                    geneAnnotationTrackColor = "darkgreen",
+#'                    initialLocus = "chr5:88,621,308-89,001,037",
+#'                    visibilityWindow = 5000000)
 #'    }
 #'
-
 setMethod('setCustomGenome', 'igvR',
 
-   function (obj,
+   function(obj,
              id,
              genomeName,
              fastaURL,
              fastaIndexURL,
-             chromosomeAliasURL=NA,
-             cytobandURL=NA,
-             geneAnnotationName=NA,
-             geneAnnotationURL=NA,
-             geneAnnotationTrackHeight=200,
-             geneAnnotationTrackColor="darkblue",
-             initialLocus="all",
-             visibilityWindow=1000000) {
+             chromosomeAliasURL = NA,
+             cytobandURL = NA,
+             geneAnnotationName = NA,
+             geneAnnotationURL = NA,
+             geneAnnotationTrackHeight = 200,
+             geneAnnotationTrackColor = "darkblue",
+             initialLocus = "all",
+             visibilityWindow = 1000000) {
      BrowserViz:::log("igvR::setCustomGenome")
-     payload <- list(id=id,
-                     genomeName=genomeName,
-                     fastaURL=fastaURL,
-                     fastaIndexURL=fastaIndexURL,
-                     chromosomeAliasURL=chromosomeAliasURL,
-                     cytobandURL=cytobandURL,
-                     geneAnnotationName=geneAnnotationName,
-                     geneAnnotationURL=geneAnnotationURL,
-                     geneAnnotationTrackHeight=geneAnnotationTrackHeight,
-                     geneAnnotationTrackColor=geneAnnotationTrackColor,
-                     initialLocus=initialLocus,
-                     visibilityWindow=visibilityWindow)
+     payload <- list(id = id,
+                     genomeName = genomeName,
+                     fastaURL = fastaURL,
+                     fastaIndexURL = fastaIndexURL,
+                     chromosomeAliasURL = chromosomeAliasURL,
+                     cytobandURL = cytobandURL,
+                     geneAnnotationName = geneAnnotationName,
+                     geneAnnotationURL = geneAnnotationURL,
+                     geneAnnotationTrackHeight = geneAnnotationTrackHeight,
+                     geneAnnotationTrackColor = geneAnnotationTrackColor,
+                     initialLocus = initialLocus,
+                     visibilityWindow = visibilityWindow)
 
-     send(obj, list(cmd="setCustomGenome", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+     send(obj, list(cmd = "setCustomGenome", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      # enableMotifLogoPopups(obj, TRUE)
@@ -302,20 +307,19 @@ setMethod('setCustomGenome', 'igvR',
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    getSupportedGenomes(igv)
 #'    }
 #'
-
 setMethod('getSupportedGenomes', 'igvR',
 
-    function (obj) {
-       basic.offerings <-  c("hg38", "hg19", "mm10", "tair10", "rhos", "custom", "dm6", "sacCer3")
+    function(obj) {
+       basic.offerings <- c("hg38", "hg19", "mm10", "tair10", "rhos", "custom", "dm6", "sacCer3")
        current.genomes.file <- "https://igv.org/genomes/genomes.json"
-       if(!url.exists(current.genomes.file))
+       if (!url.exists(current.genomes.file))
           return(basic.offerings)
-       current.genomes.raw <- readLines(current.genomes.file, warn=FALSE, skipNul=TRUE)
+       current.genomes.raw <- readLines(current.genomes.file, warn = FALSE, skipNul = TRUE)
        tbl.genomes <- fromJSON(current.genomes.raw)
        tbl.genomes$id
        })
@@ -342,7 +346,7 @@ setMethod('getSupportedGenomes', 'igvR',
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg38")
 #'    showGenomicRegion(igv, "MEF2C")
@@ -350,13 +354,12 @@ setMethod('getSupportedGenomes', 'igvR',
 #'      # list(chrom="chr5", start=88717241, end=88884466, string="chr5:88,717,241-88,884,466")
 #'    }
 #'
-
 setMethod('getGenomicRegion', 'igvR',
 
-   function (obj) {
+   function(obj) {
      payload <- ""
-     send(obj, list(cmd="getGenomicRegion", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+     send(obj, list(cmd = "getGenomicRegion", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      x <- getBrowserResponse(obj);
@@ -366,9 +369,9 @@ setMethod('getGenomicRegion', 'igvR',
        # the real solution lies in jim robinson adding the option to resolve a
        # track display promise only when the browser has finished rendering
 
-     plausible.chromLoc.string <- nchar(x) >= 10 && grepl(":", x, fixed=TRUE) && grepl("-", x, fixed=TRUE)
+     plausible.chromLoc.string <- nchar(x) >= 10 && grepl(":", x, fixed = TRUE) && grepl("-", x, fixed = TRUE)
 
-     if(!plausible.chromLoc.string)
+     if (!plausible.chromLoc.string)
         return("genomic region not available, please try again in a few moments")
 
      return(.parseChromLocString(x))
@@ -391,7 +394,7 @@ setMethod('getGenomicRegion', 'igvR',
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg38")
 #'    showGenomicRegion(igv, "MEF2C")
@@ -399,26 +402,26 @@ setMethod('getGenomicRegion', 'igvR',
 #'       #--------------------
 #'       # zoom out 2kb
 #'       #--------------------
-#'    showGenomicRegion(igv, with(x, sprintf("%s:%d-%d", chrom, start-1000, end+1000)))
+#'    showGenomicRegion(igv, with(x, sprintf("%s:%d-%d", chrom, start - 1000, end + 1000)))
 #'    }
 #'
 setMethod('showGenomicRegion', 'igvR',
 
-   function (obj, region) {
-      if(is.list(region)){
+   function(obj, region) {
+      if (is.list(region)) {
          valid.list <- all(c("chrom", "start", "end") %in% names(region))
          stopifnot(valid.list)
          regionString <- sprintf("%s:%d-%d", region$chrom, region$start, region$end)
-         }  # if region is a list
-      else if(is.character(region)) {
+         } # if region is a list
+      else if (is.character(region)) {
          regionString <- region
          }
-      else{
+      else {
           stop("must be a chromLoc string, e.g., 'chr1:10-60' or a search term, e.g., 'MYC'");
           }
-     payload <- list(regionString=regionString)
-     send(obj, list(cmd="showGenomicRegion", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+     payload <- list(regionString = regionString)
+     send(obj, list(cmd = "showGenomicRegion", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      getBrowserResponse(obj);
@@ -438,9 +441,9 @@ setMethod('showGenomicRegion', 'igvR',
 #'
 setMethod('zoomOut', 'igvR',
 
-    function (obj) {
-      send(obj, list(cmd="zoomOut", callback="handleResponse", status="request", payload=""))
-      while (!browserResponseReady(obj)){
+    function(obj) {
+      send(obj, list(cmd = "zoomOut", callback = "handleResponse", status = "request", payload = ""))
+      while (!browserResponseReady(obj)) {
          service(100)
          }
       getBrowserResponse(obj);
@@ -460,9 +463,9 @@ setMethod('zoomOut', 'igvR',
 #'
  setMethod('zoomIn', 'igvR',
 
-    function (obj) {
-      send(obj, list(cmd="zoomIn", callback="handleResponse", status="request", payload=""))
-      while (!browserResponseReady(obj)){
+    function(obj) {
+      send(obj, list(cmd = "zoomIn", callback = "handleResponse", status = "request", payload = ""))
+      while (!browserResponseReady(obj)) {
          service(100)
          }
       getBrowserResponse(obj);
@@ -483,10 +486,10 @@ setMethod('zoomOut', 'igvR',
 #'
 setMethod('setTrackClickFunction', 'igvR',
 
-   function (obj, javascriptFunction) {
-     payload <- list(jsFunction=javascriptFunction)
-     send(obj, list(cmd="setTrackClickFunction", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+   function(obj, javascriptFunction) {
+     payload <- list(jsFunction = javascriptFunction)
+     send(obj, list(cmd = "setTrackClickFunction", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      invisible(getBrowserResponse(obj));
@@ -506,34 +509,33 @@ setMethod('setTrackClickFunction', 'igvR',
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg38")
 #'    showGenomicRegion(igv, "MEF2C")
 #'    base.loc <- 88883100
-#'    tbl <- data.frame(chrom=rep("chr5", 3),
-#'                      start=c(base.loc, base.loc+100, base.loc + 250),
-#'                      end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                      name=c("a", "b", "c"),
-#'                      score=runif(3),
-#'                      strand=rep("*", 3),
-#'                      stringsAsFactors=FALSE)
-#'    track <- DataFrameAnnotationTrack("dataframeTest", tbl, color="red",
-#'                                       displayMode="EXPANDED")
+#'    tbl <- data.frame(chrom = rep("chr5", 3),
+#'                      start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                      end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                      name = c("a", "b", "c"),
+#'                      score = runif(3),
+#'                      strand = rep("*", 3),
+#'                      stringsAsFactors = FALSE)
+#'    track <- DataFrameAnnotationTrack("dataframeTest", tbl, color = "red",
+#'                                       displayMode = "EXPANDED")
 #'    showGenomicRegion(igv, "chr5:88,881,962-88,885,045")
 #'    displayTrack(igv, track)
 #'    }
-
 setMethod('displayTrack', 'igvR',
 
-   function (obj, track, deleteTracksOfSameName=TRUE) {
+   function(obj, track, deleteTracksOfSameName = TRUE) {
      # sourceType <- track@sourceType
      # fileFormat <- track@fileFormat
      # branch and dispatch on the above 3 values
 
    track.info <- trackInfo(track)
 
-   if(deleteTracksOfSameName){
+   if (deleteTracksOfSameName) {
       removeTracksByName(obj, track@trackName);
       }
 
@@ -543,33 +545,33 @@ setMethod('displayTrack', 'igvR',
    BrowserViz:::log(track.info)
 
    with(track.info,
-       if(trackType == "variant" && source == "file" && fileFormat == "vcf")
+       if (trackType == "variant" && source == "file" && fileFormat == "vcf")
           .displayVariantTrack(obj, track)
-       else if(trackType == "annotation" && source == "file" && fileFormat == "bed")
+       else if (trackType == "annotation" && source == "file" && fileFormat == "bed")
           .displayAnnotationTrack(obj, track)
-       else if(trackType == "quantitative" && source == "file" && fileFormat == "bedGraph")
+       else if (trackType == "quantitative" && source == "file" && fileFormat == "bedGraph")
           .displayQuantitativeTrack(obj, track)
-       else if(trackType == "genomicalignment" && source == "file" && fileFormat == "bam")
+       else if (trackType == "genomicalignment" && source == "file" && fileFormat == "bam")
           .displayAlignmentTrack(obj, track)
-       else if(trackType == "remotealignment" && source == "url" && fileFormat == "bam")
+       else if (trackType == "remotealignment" && source == "url" && fileFormat == "bam")
           .displayRemoteAlignmentTrack(obj, track)
-       else if(trackType == "pairedendannotation" && source == "file" && fileFormat == "bedpe")
+       else if (trackType == "pairedendannotation" && source == "file" && fileFormat == "bedpe")
           .displayBedpeInteractionsTrack(obj, track)
-       else if(trackType == "gwas" && source == "file" && fileFormat == "gwas")
+       else if (trackType == "gwas" && source == "file" && fileFormat == "gwas")
           .displayGWASTrack(obj, track)
-       else if(trackType == "gwas" && source == "url" && fileFormat == "gwas")
+       else if (trackType == "gwas" && source == "url" && fileFormat == "gwas")
           .displayGWASUrlTrack(obj, track)
-       else if(trackType == "annotation" && fileFormat == "gff3")
+       else if (trackType == "annotation" && fileFormat == "gff3")
           .displayGFF3Track(obj, track)
-       else if(trackType == "alignment" && source == "url" && fileFormat == "cram")
+       else if (trackType == "alignment" && source == "url" && fileFormat == "cram")
           .displayCramTrack(obj, track)
-       else{
+       else {
           stop(sprintf("unrecogized track type, trackType: %s, source: %s, fileFormat: %s",
                        trackType, source, fileFormat))
           }
        ) # with track.info
 
-   while (!browserResponseReady(obj)){
+   while (!browserResponseReady(obj)) {
       service(100)
       }
 
@@ -592,32 +594,32 @@ setMethod('displayTrack', 'igvR',
 
    direct.unhosted.vcf <- !(is.list(track@vcf.url) && all(c("data", "index") %in% names(track@vcf.url)))
 
-   if(direct.unhosted.vcf){
-      if(length(track@vcf.obj) > 10e5)
+   if (direct.unhosted.vcf) {
+      if (length(track@vcf.obj) > 10e5)
          BrowserViz:::log(sprintf("vcf objects above %d rows may take a long time to render in igvR", 10e5))
-      temp.filename <- tempfile(fileext=".vcf")
+      temp.filename <- tempfile(fileext = ".vcf")
       BrowserViz:::log(sprintf("   writing vcf of size %d to %s", length(track@vcf.obj), temp.filename))
       writeVcf(track@vcf.obj, temp.filename)
       dataURL <- sprintf("%s?%s", igv@uri, temp.filename)
       indexURL <- ""
       }
-   else{
+   else {
       dataURL <- track@vcf.url$data
       indexURL <- track@vcf.url$index
       }
 
-   payload <- list(name=track@trackName,
-                   dataURL=dataURL,
-                   indexURL=indexURL,
-                   displayMode=track@displayMode,
-                   visibilityWindow=track@visibilityWindow,
-                   color=track@color,
-                   homvarColor=track@homvarColor,
-                   hetvarColor=track@hetvarColor,
-                   homrefColor=track@homrefColor,
-                   trackHeight=200)
+   payload <- list(name = track@trackName,
+                   dataURL = dataURL,
+                   indexURL = indexURL,
+                   displayMode = track@displayMode,
+                   visibilityWindow = track@visibilityWindow,
+                   color = track@color,
+                   homvarColor = track@homvarColor,
+                   hetvarColor = track@hetvarColor,
+                   homrefColor = track@homrefColor,
+                   trackHeight = 200)
 
-    send(igv, list(cmd="displayVcfTrackFromUrl", callback="handleResponse", status="request", payload=payload))
+    send(igv, list(cmd = "displayVcfTrackFromUrl", callback = "handleResponse", status = "request", payload = payload))
 
 } # .displayVariantTrack
 #----------------------------------------------------------------------------------------------------
@@ -625,11 +627,11 @@ setMethod('displayTrack', 'igvR',
 {
    stopifnot("GenomicAlignmentTrack" %in% is(track))
 
-   if(length(track@alignment) > 10e5)
+   if (length(track@alignment) > 10e5)
        BrowserViz:::log(sprintf("alignment objects above %d rows may take a long time to render in igvR", 10e5))
-   temp.filename <- tempfile(fileext=".bam")
+   temp.filename <- tempfile(fileext = ".bam")
    BrowserViz:::log(sprintf("   writing bam file of size %d to %s", length(track@alignment), temp.filename))
-   export(track@alignment, temp.filename, format="BAM")
+   export(track@alignment, temp.filename, format = "BAM")
    dataURL <- sprintf("%s?%s", igv@uri, temp.filename)
    BrowserViz:::log(sprintf("bam url: %s", dataURL))
    indexURL <- sprintf("%s.bai", dataURL)
@@ -637,16 +639,17 @@ setMethod('displayTrack', 'igvR',
 
    # this will fail if color is neither a recognized name nor an #RRBBGG hex string
 
-   hex.color <- rgb(t(col2rgb(track@color))/255)
+   hex.color <- rgb(t(col2rgb(track@color)) / 255)
 
-   payload <- list(name=track@trackName,
-                   dataURL=dataURL,
-                   indexURL=indexURL,
-                   color=hex.color,
-                   visibilityWindow=track@visibilityWindow,
-                   trackHeight=track@height)
+   payload <- list(name = track@trackName,
+                   dataURL = dataURL,
+                   indexURL = indexURL,
+                   color = hex.color,
+                   visibilityWindow = track@visibilityWindow,
+                   trackHeight = track@height)
 
-    send(igv, list(cmd="displayAlignmentTrackFromUrl", callback="handleResponse", status="request", payload=payload))
+    send(igv, list(cmd = "displayAlignmentTrackFromUrl", callback = "handleResponse",
+                   status = "request", payload = payload))
 
 } # .displayAlignmentTrack
 #----------------------------------------------------------------------------------------------------
@@ -663,16 +666,17 @@ setMethod('displayTrack', 'igvR',
 
    # this will fail if color is neither a recognized name nor an #RRBBGG hex string
 
-   hex.color <- rgb(t(col2rgb(track@color))/255)
+   hex.color <- rgb(t(col2rgb(track@color)) / 255)
 
-   payload <- list(name=track@trackName,
-                   dataURL=dataURL,
-                   indexURL=indexURL,
-                   color=hex.color,
-                   visibilityWindow=track@visibilityWindow,
-                   trackHeight=track@height)
+   payload <- list(name = track@trackName,
+                   dataURL = dataURL,
+                   indexURL = indexURL,
+                   color = hex.color,
+                   visibilityWindow = track@visibilityWindow,
+                   trackHeight = track@height)
 
-    send(igv, list(cmd="displayAlignmentTrackFromUrl", callback="handleResponse", status="request", payload=payload))
+    send(igv, list(cmd = "displayAlignmentTrackFromUrl", callback = "handleResponse",
+                   status = "request", payload = payload))
 
 } # .displayRemoteAlignmentTrack
 
@@ -682,43 +686,43 @@ setMethod('displayTrack', 'igvR',
 
    dataURL <- track@cramUrl
    indexURL <- track@indexUrl
-   
+
    # Color handling
    hex.color <- tryCatch(
-      rgb(t(col2rgb(track@color))/255),
+      rgb(t(col2rgb(track@color)) / 255),
       error = function(e) "gray"
    )
 
-   payload <- list(name=track@trackName,
-                   dataURL=dataURL,
-                   indexURL=indexURL,
-                   color=hex.color,
-                   visibilityWindow=track@visibilityWindow,
-                   trackHeight=track@height)
+   payload <- list(name = track@trackName,
+                   dataURL = dataURL,
+                   indexURL = indexURL,
+                   color = hex.color,
+                   visibilityWindow = track@visibilityWindow,
+                   trackHeight = track@height)
 
    # Send to a NEW javascript handler
-   send(igv, list(cmd="displayCramTrackFromUrl", callback="handleResponse", status="request", payload=payload))
+   send(igv, list(cmd = "displayCramTrackFromUrl", callback = "handleResponse", status = "request", payload = payload))
 }
 
 #----------------------------------------------------------------------------------------------------
 .writeMotifLogoImagesUpdateTrackNames <- function(tbl, igvApp.uri)
 {
-   rows.with.motifdb <- grep("motifdb::", tbl$name, ignore.case=TRUE)
+   rows.with.motifdb <- grep("motifdb::", tbl$name, ignore.case = TRUE)
 
-   if(length(rows.with.motifdb) == 0)
+   if (length(rows.with.motifdb) == 0)
       return(tbl)
 
-   for(i in rows.with.motifdb){
-      motif.id <- sub("motifdb::", "", tbl$name[i], ignore.case=TRUE)
+   for (i in rows.with.motifdb) {
+      motif.id <- sub("motifdb::", "", tbl$name[i], ignore.case = TRUE)
       pwm <- MotifDb::MotifDb[[motif.id]]
-      if(is.null(pwm))
+      if (is.null(pwm))
          next;
-      filename <- tempfile(fileext=".png")
-      png(filename, width=250, height=250)
-      seqLogo::seqLogo(pwm, xaxis=FALSE, yaxis=FALSE)
+      filename <- tempfile(fileext = ".png")
+      png(filename, width = 250, height = 250)
+      seqLogo::seqLogo(pwm, xaxis = FALSE, yaxis = FALSE)
       dev.off()
       new.url <- sprintf("%s?%s", igvApp.uri, filename)
-      tbl$name[i]=sprintf(new.url)
+      tbl$name[i] = sprintf(new.url)
       } # for i
 
    tbl
@@ -730,25 +734,25 @@ setMethod('displayTrack', 'igvR',
    stopifnot("igvAnnotationTrack" %in% is(track))
    track.info <- trackInfo(track)
 
-   temp.filename <- tempfile(fileext=".bed")
+   temp.filename <- tempfile(fileext = ".bed")
 
-   if(track.info$class == "DataFrameAnnotationTrack"){
+   if (track.info$class == "DataFrameAnnotationTrack") {
       tbl <- track@coreObject
-      tbl <- tbl[order(tbl[,1], tbl[,2], decreasing=FALSE),]
-      motifDb.entries <- grep("MotifDb:", tbl$name, ignore.case=TRUE)
-      if(length(motifDb.entries) > 0)
+      tbl <- tbl[order(tbl[, 1], tbl[, 2], decreasing = FALSE), ]
+      motifDb.entries <- grep("MotifDb:", tbl$name, ignore.case = TRUE)
+      if (length(motifDb.entries) > 0)
          tbl <- .writeMotifLogoImagesUpdateTrackNames(tbl, igv@uri)
-      write.table(tbl, row.names=FALSE, col.names=FALSE, quote=FALSE, sep="\t", file=temp.filename)
+      write.table(tbl, row.names = FALSE, col.names = FALSE, quote = FALSE, sep = "\t", file = temp.filename)
       }
-   else if(track.info$class == "UCSCBedAnnotationTrack"){
+   else if (track.info$class == "UCSCBedAnnotationTrack") {
       gr.bed <- track@coreObject
-      export(gr.bed, temp.filename, format="BED")
+      export(gr.bed, temp.filename, format = "BED")
       }
-   else if(track.info$class == "GRangesAnnotationTrack"){
+   else if (track.info$class == "GRangesAnnotationTrack") {
       gr.bed <- track@coreObject
-      export(gr.bed, temp.filename, format="BED")
+      export(gr.bed, temp.filename, format = "BED")
       }
-   else{
+   else {
       stop("cannot display annotation track of class %s", track.info$class)
       }
 
@@ -760,14 +764,14 @@ setMethod('displayTrack', 'igvR',
    indexURL <- ""
 
 
-   payload <- list(name=track@trackName,
-                   dataURL=dataURL,
-                   indexURL=indexURL,
-                   displayMode=track@displayMode,
-                   color=track@color,
-                   trackHeight=track@height)
+   payload <- list(name = track@trackName,
+                   dataURL = dataURL,
+                   indexURL = indexURL,
+                   displayMode = track@displayMode,
+                   color = track@color,
+                   trackHeight = track@height)
 
-   send(igv, list(cmd="displayBedTrackFromUrl", callback="handleResponse", status="request", payload=payload))
+   send(igv, list(cmd = "displayBedTrackFromUrl", callback = "handleResponse", status = "request", payload = payload))
 
 
 } # .displayAnnotationTrack
@@ -780,52 +784,53 @@ setMethod('displayTrack', 'igvR',
                                      "UCSCBedGraphQuantitativeTrack",
                                      "GRangesQuantitativeTrack"))
 
-   #temp.filename <- tempfile(fileext=sprintf(".%s", track.info$fileFormat))
-   temp.filename <- tempfile(fileext=".bedgraph")
+   # temp.filename <- tempfile(fileext=sprintf(".%s", track.info$fileFormat))
+   temp.filename <- tempfile(fileext = ".bedgraph")
 
-   if(track.info$class == "DataFrameQuantitativeTrack"){
+   if (track.info$class == "DataFrameQuantitativeTrack") {
       tbl <- track@coreObject
-      tbl <- tbl[order(tbl[,1], tbl[,2], decreasing=FALSE),]
+      tbl <- tbl[order(tbl[, 1], tbl[, 2], decreasing = FALSE), ]
       BrowserViz:::log(sprintf("writing data.frame quantitative track to %s", temp.filename))
-      write.table(tbl, row.names=FALSE, col.names=FALSE, quote=FALSE, sep="\t", file=temp.filename)
+      write.table(tbl, row.names = FALSE, col.names = FALSE, quote = FALSE, sep = "\t", file = temp.filename)
       }
-   else if(track.info$class == "UCSCBedGraphQuantitativeTrack"){
+   else if (track.info$class == "UCSCBedGraphQuantitativeTrack") {
       gr.bedGraph <- track@coreObject
-      export(gr.bedGraph, temp.filename, format="bedGraph")
+      export(gr.bedGraph, temp.filename, format = "bedGraph")
       }
 
-   else if(track.info$class == "GRangesQuantitativeTrack"){
+   else if (track.info$class == "GRangesQuantitativeTrack") {
       gr <- track@coreObject
          # identify score column.  we want just chrom, start, end, score
-      if(!ncol(mcols(gr)) == 1) stop("must have exactly one numeric metadata column")
+      if (!ncol(mcols(gr)) == 1) stop("must have exactly one numeric metadata column")
       tbl.tmp <- as.data.frame(gr)
       scores <- tbl.tmp[, ncol(tbl.tmp)]
-      if(!("numeric" %in% is(scores))) stop("single metadata column, interpreted as scores, must be numeric")
+      if (!("numeric" %in% is(scores))) stop("single metadata column, interpreted as scores, must be numeric")
       # if(diff(range(scores)) == 0) stop("bedGraph track requires variable scores in single metadata column")
       tbl.tmp <- tbl.tmp[, c(seq_len(3), ncol(tbl.tmp))]
-      tbl.tmp.ordered <- tbl.tmp[order(tbl.tmp[,1], tbl.tmp[,2], decreasing=FALSE),]
+      tbl.tmp.ordered <- tbl.tmp[order(tbl.tmp[, 1], tbl.tmp[, 2], decreasing = FALSE), ]
       BrowserViz:::log(sprintf("writing GRangesQuantitativeTrack to %s", temp.filename))
-      write.table(tbl.tmp.ordered, sep="\t", row.names=FALSE, col.names=FALSE, quote=FALSE, file=temp.filename)
+      write.table(tbl.tmp.ordered, sep = "\t", row.names = FALSE, col.names = FALSE,
+                  quote = FALSE, file = temp.filename)
       }
 
    dataURL <- sprintf("%s?%s", igv@uri, temp.filename)
    indexURL <- ""
    BrowserViz:::log(sprintf("asking brower to display: %s", dataURL))
 
-   payload <- list(name=track@trackName,
-                   fileFormat=track.info$fileFormat,
-                   dataURL=dataURL,
-                   indexURL=indexURL,
-                   color=track@color,
-                   trackHeight=track@height,
-                   autoscale=track@autoscale,
-                   min=track@min,
-                   max=track@max)
+   payload <- list(name = track@trackName,
+                   fileFormat = track.info$fileFormat,
+                   dataURL = dataURL,
+                   indexURL = indexURL,
+                   color = track@color,
+                   trackHeight = track@height,
+                   autoscale = track@autoscale,
+                   min = track@min,
+                   max = track@max)
 
    BrowserViz:::log(sprintf("--- to igvApp.js: displayQuantitativeTrackFromUrl"))
    print(payload)
-   send(igv, list(cmd="displayQuantitativeTrackFromUrl", callback="handleResponse",
-                  status="request", payload=payload))
+   send(igv, list(cmd = "displayQuantitativeTrackFromUrl", callback = "handleResponse",
+                  status = "request", payload = payload))
 
 
 } # .displayQuantitativeTrack
@@ -835,11 +840,11 @@ setMethod('displayTrack', 'igvR',
    stopifnot("BedpeInteractionsTrack" %in% is(track))
    track.info <- trackInfo(track)
 
-   temp.filename <- tempfile(fileext=".bedpe")
+   temp.filename <- tempfile(fileext = ".bedpe")
 
    tbl <- track@coreObject
-   tbl <- tbl[order(tbl[,1], tbl[,2], decreasing=FALSE),]
-   write.table(tbl, row.names=FALSE, col.names=FALSE, quote=FALSE, sep="\t", file=temp.filename)
+   tbl <- tbl[order(tbl[, 1], tbl[, 2], decreasing = FALSE), ]
+   write.table(tbl, row.names = FALSE, col.names = FALSE, quote = FALSE, sep = "\t", file = temp.filename)
 
    BrowserViz:::log(sprintf("-------- .displayBedpeInteractionsTrack, trackName: %s", track@trackName))
    BrowserViz:::log(sprintf("         temp.filename: %s", temp.filename))
@@ -848,15 +853,15 @@ setMethod('displayTrack', 'igvR',
    dataURL <- sprintf("%s?%s", igv@uri, temp.filename)
    indexURL <- ""
 
-   payload <- list(name=track@trackName,
-                   dataURL=dataURL,
-                   indexURL=indexURL,
-                   displayMode=track@displayMode,
-                   color=track@color,
-                   trackHeight=track@height)
+   payload <- list(name = track@trackName,
+                   dataURL = dataURL,
+                   indexURL = indexURL,
+                   displayMode = track@displayMode,
+                   color = track@color,
+                   trackHeight = track@height)
 
-   send(igv, list(cmd="displayBedpeInteractionsTrackFromUrl", callback="handleResponse",
-                  status="request", payload=payload))
+   send(igv, list(cmd = "displayBedpeInteractionsTrackFromUrl", callback = "handleResponse",
+                  status = "request", payload = payload))
 
 } # .displayBedpeInteractionsTrack
 #----------------------------------------------------------------------------------------------------
@@ -866,14 +871,14 @@ setMethod('displayTrack', 'igvR',
    stopifnot("GWASTrack" %in% is(track))
    track.info <- trackInfo(track)
 
-   temp.filename <- tempfile(fileext=".GWAS")
+   temp.filename <- tempfile(fileext = ".GWAS")
    tbl <- track@coreObject
 
    gwas.format <- "gwas"
 
    # tbl <- tbl[order(tbl[,1], tbl[,2], decreasing=FALSE),]
-   write.table(tbl, row.names=FALSE, col.names=TRUE, quote=FALSE, sep="\t",
-               file=temp.filename)
+   write.table(tbl, row.names = FALSE, col.names = TRUE, quote = FALSE, sep = "\t",
+               file = temp.filename)
 
    BrowserViz:::log(sprintf("-------- .displayGWASTrack, trackName: %s", track@trackName))
    BrowserViz:::log(sprintf("         temp.filename: %s", temp.filename))
@@ -882,27 +887,27 @@ setMethod('displayTrack', 'igvR',
    dataURL <- sprintf("%s?%s", igv@uri, temp.filename)
    indexURL <- ""
 
-   payload <- list(name=track@trackName,
-                   dataURL=dataURL,
-                   dataFormat="gwas",
-                   type="gwas",
-                   indexURL=indexURL,
-                   color=track@color,
-                   trackHeight=track@height,
-                   chromCol=track@chrom.col,
-                   posCol=track@pos.col,
-                   pvalCol=track@pval.col,
-                   autoscale=track@autoscale,
-                   min=track@min,
-                   max=track@max,
-                   colorTable=track@colorTable
+   payload <- list(name = track@trackName,
+                   dataURL = dataURL,
+                   dataFormat = "gwas",
+                   type = "gwas",
+                   indexURL = indexURL,
+                   color = track@color,
+                   trackHeight = track@height,
+                   chromCol = track@chrom.col,
+                   posCol = track@pos.col,
+                   pvalCol = track@pval.col,
+                   autoscale = track@autoscale,
+                   min = track@min,
+                   max = track@max,
+                   colorTable = track@colorTable
                    )
 
    BrowserViz:::log("--- about to request 'displayGWASTrackFromUrl'")
    # BrowserViz:::log(payload)
 
-   send(igv, list(cmd="displayGWASTrackFromUrl", callback="handleResponse",
-                  status="request", payload=payload))
+   send(igv, list(cmd = "displayGWASTrackFromUrl", callback = "handleResponse",
+                  status = "request", payload = payload))
 
 } # .displayGWASTrack
 #----------------------------------------------------------------------------------------------------
@@ -918,28 +923,28 @@ setMethod('displayTrack', 'igvR',
 
    dataURL <- track@coreObject
 
-   payload <- list(name=track@trackName,
-                   dataURL=dataURL,
-                   dataFormat="gwas",
-                   type="gwas",
-                   indexURL="",
-                   displayMode="EXPANDED",
-                   trackHeight=track@height,
-                   chromCol=track@chrom.col,
-                   posCol=track@pos.col,
-                   pvalCol=track@pval.col,
-                   autoscale=track@autoscale,
-                   min=track@min,
-                   max=track@max,
-                   color=track@color,
-                   colorTable=track@colorTable
+   payload <- list(name = track@trackName,
+                   dataURL = dataURL,
+                   dataFormat = "gwas",
+                   type = "gwas",
+                   indexURL = "",
+                   displayMode = "EXPANDED",
+                   trackHeight = track@height,
+                   chromCol = track@chrom.col,
+                   posCol = track@pos.col,
+                   pvalCol = track@pval.col,
+                   autoscale = track@autoscale,
+                   min = track@min,
+                   max = track@max,
+                   color = track@color,
+                   colorTable = track@colorTable
                    )
 
    BrowserViz:::log("--- about to request 'displayGWASTrakFromUrl'")
    BrowserViz:::log(payload)
 
-   send(igv, list(cmd="displayGWASTrackFromUrl", callback="handleResponse",
-                  status="request", payload=payload))
+   send(igv, list(cmd = "displayGWASTrackFromUrl", callback = "handleResponse",
+                  status = "request", payload = payload))
 
 } # .displayGWASUrlTrack
 #----------------------------------------------------------------------------------------------------
@@ -949,23 +954,23 @@ setMethod('displayTrack', 'igvR',
    stopifnot("GFF3Track" %in% is(track))
    track.info <- trackInfo(track)
 
-   payload <- list(name=track@trackName,
-                   displayMode=track@displayMode,
-                   color=track@color,
-                   trackHeight=track@height,
-                   colorTable=track@colorTable,
-                   colorBy=track@colorByAttribute
+   payload <- list(name = track@trackName,
+                   displayMode = track@displayMode,
+                   color = track@color,
+                   trackHeight = track@height,
+                   colorTable = track@colorTable,
+                   colorBy = track@colorByAttribute
                    )
 
-   if(!is.na(track@url) & grepl("^http", track@url)){
+   if (!is.na(track@url) & grepl("^http", track@url)) {
        payload$dataURL <- track@url
        payload$indexURL <- track@indexURL
        }
 
-   if(is.na(track@url) & nrow(track@tbl) > 0){
-      temp.filename <- tempfile(fileext=".GFF3")
-      write.table(track@tbl, row.names=FALSE, col.names=FALSE, quote=FALSE, sep="\t",
-                  file=temp.filename)
+   if (is.na(track@url) & nrow(track@tbl) > 0) {
+      temp.filename <- tempfile(fileext = ".GFF3")
+      write.table(track@tbl, row.names = FALSE, col.names = FALSE, quote = FALSE, sep = "\t",
+                  file = temp.filename)
       payload$dataURL <- sprintf("%s?%s", igv@uri, temp.filename)
       payload$indexURL <- ""
       }
@@ -976,8 +981,8 @@ setMethod('displayTrack', 'igvR',
    BrowserViz:::log("--- about to request 'displayGFF3TrakFromUrl'")
    BrowserViz:::log(payload)
 
-   send(igv, list(cmd="displayGFF3Track", callback="handleResponse",
-                  status="request", payload=payload))
+   send(igv, list(cmd = "displayGFF3Track", callback = "handleResponse",
+                  status = "request", payload = payload))
 
 } # .displayGFF3Track
 #----------------------------------------------------------------------------------------------------
@@ -995,10 +1000,10 @@ setMethod('displayTrack', 'igvR',
 #'
 setMethod('showTrackLabels', 'igvR',
 
-   function (obj, newState) {
-     payload <- list(newState=newState)
-     send(obj, list(cmd="showTrackLabels", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+   function(obj, newState) {
+     payload <- list(newState = newState)
+     send(obj, list(cmd = "showTrackLabels", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      invisible(getBrowserResponse(obj));
@@ -1017,18 +1022,17 @@ setMethod('showTrackLabels', 'igvR',
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg19")
-#'    getTrackNames(igv)     # "Gencode v18"
+#'    getTrackNames(igv) # "Gencode v18"
 #'    }
-
 setMethod('getTrackNames', 'igvR',
 
-   function (obj) {
+   function(obj) {
      payload <- ""
-     send(obj, list(cmd="getTrackNames", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+     send(obj, list(cmd = "getTrackNames", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      getBrowserResponse(obj);
@@ -1050,22 +1054,22 @@ setMethod('getTrackNames', 'igvR',
 #' @export
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg19")
 #'    showGenomicRegion(igv, "MEF2C")
 #'      # create three arbitrary tracks
 #'    base.loc <- 88883100
-#'    tbl <- data.frame(chrom=rep("chr5", 3),
-#'                      start=c(base.loc, base.loc+100, base.loc + 250),
-#'                      end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                      name=c("a", "b", "c"),
-#'                      score=runif(3),
-#'                      strand=rep("*", 3),
-#'                      stringsAsFactors=FALSE)
-#'    track.1 <- DataFrameAnnotationTrack("track.1", tbl, color="red", displayMode="SQUISHED")
-#'    track.2 <- DataFrameAnnotationTrack("track.2", tbl, color="blue", displayMode="SQUISHED")
-#'    track.3 <- DataFrameAnnotationTrack("track.3", tbl, color="green", displayMode="SQUISHED")
+#'    tbl <- data.frame(chrom = rep("chr5", 3),
+#'                      start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                      end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                      name = c("a", "b", "c"),
+#'                      score = runif(3),
+#'                      strand = rep("*", 3),
+#'                      stringsAsFactors = FALSE)
+#'    track.1 <- DataFrameAnnotationTrack("track.1", tbl, color = "red", displayMode = "SQUISHED")
+#'    track.2 <- DataFrameAnnotationTrack("track.2", tbl, color = "blue", displayMode = "SQUISHED")
+#'    track.3 <- DataFrameAnnotationTrack("track.3", tbl, color = "green", displayMode = "SQUISHED")
 #'    displayTrack(igv, track.1)
 #'    displayTrack(igv, track.2)
 #'    displayTrack(igv, track.3)
@@ -1076,13 +1080,12 @@ setMethod('getTrackNames', 'igvR',
 #'      #----------------------------------------
 #'    removeTracksByName(igv, getTrackNames(igv)[-1])
 #'    }
-
 setMethod('removeTracksByName', 'igvR',
 
-   function (obj, trackNames) {
+   function(obj, trackNames) {
      payload <- trackNames
-     send(obj, list(cmd="removeTracksByName", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+     send(obj, list(cmd = "removeTracksByName", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      getBrowserResponse(obj);
@@ -1105,13 +1108,13 @@ setMethod('removeTracksByName', 'igvR',
 #'
 setMethod('setTrackHeight', 'igvR',
 
-   function (obj, trackName, newHeight) {
+   function(obj, trackName, newHeight) {
 
      BrowserViz:::log(sprintf("--- entering igvR::setTrackHeight: %s, %d", trackName, newHeight))
-     payload <- list(trackName=trackName, newHeight=newHeight)
+     payload <- list(trackName = trackName, newHeight = newHeight)
 
-     send(obj, list(cmd="setBrowserTrackHeight", callback="handleResponse", status="request", payload=payload))
-     while (!browserResponseReady(obj)){
+     send(obj, list(cmd = "setBrowserTrackHeight", callback = "handleResponse", status = "request", payload = payload))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      getBrowserResponse(obj);
@@ -1132,9 +1135,9 @@ setMethod('setTrackHeight', 'igvR',
 #'
 
 setMethod('saveToSVG', 'igvR',
-     function(obj, filename){
-         send(obj, list(cmd="getSVG", callback="handleResponse", status="request", payload=""))
-     while (!browserResponseReady(obj)){
+     function(obj, filename) {
+         send(obj, list(cmd = "getSVG", callback = "handleResponse", status = "request", payload = ""))
+     while (!browserResponseReady(obj)) {
         service(100)
         }
      svgText <- getBrowserResponse(obj);
@@ -1170,7 +1173,7 @@ setMethod('saveToSVG', 'igvR',
 #' @return No return value, called for side effects
 #'
 #' @examples
-#' if(interactive()){
+#' if (interactive()) {
 #'    igv <- igvR()
 #'    setGenome(igv, "hg38")
 #'    new.region <- "chr5:88,882,214-88,884,364"
@@ -1180,23 +1183,23 @@ setMethod('saveToSVG', 'igvR',
 #'                       "fubar",
 #'                       "MotifDb::Hsapiens-jaspar2018-MEF2C-MA0497.1")
 #'
-#'    tbl.regions <- data.frame(chrom=rep("chr5", 3),
-#'                              start=c(base.loc, base.loc+100, base.loc + 250),
-#'                              end=c(base.loc + 50, base.loc+120, base.loc+290),
-#'                              name=element.names,
-#'                              score=round(runif(3), 2),
-#'                              strand=rep("*", 3),
-#'                              stringsAsFactors=FALSE)
+#'    tbl.regions <- data.frame(chrom = rep("chr5", 3),
+#'                              start = c(base.loc, base.loc + 100, base.loc + 250),
+#'                              end = c(base.loc + 50, base.loc + 120, base.loc + 290),
+#'                              name = element.names,
+#'                              score = round(runif(3), 2),
+#'                              strand = rep("*", 3),
+#'                              stringsAsFactors = FALSE)
 #'
-#'    track <- DataFrameAnnotationTrack("dataframeTest", tbl.regions, color="darkGreen", displayMode="EXPANDED")
+#'    track <- DataFrameAnnotationTrack("dataframeTest", tbl.regions, color = "darkGreen", displayMode = "EXPANDED")
 #'    displayTrack(igv, track)
 #'    }
 #'
-#'@export
+#' @export
 #'
 setMethod('enableMotifLogoPopups', 'igvR',
 
-    function(obj, status){
+    function(obj, status) {
       body.parts <- c(
          'var returnValue = undefined;',
          'popoverData.forEach(function(i){',
@@ -1212,16 +1215,16 @@ setMethod('enableMotifLogoPopups', 'igvR',
          '   console.log(returnValue);',
          '   return(returnValue);'
          )
-      body <- paste(body.parts, collapse=" ")
-      x <- list(arguments="track, popoverData", body=body)
+      body <- paste(body.parts, collapse = " ")
+      x <- list(arguments = "track, popoverData", body = body)
       setTrackClickFunction(obj, x)
       })
 
 #----------------------------------------------------------------------------------------------------
 myQP <- function(queryString)
 {
-   #printf("=== igvR::myQP");
-   #print(queryString)
+   # printf("=== igvR::myQP");
+   # print(queryString)
      # for reasons not quite clear, the query string comes in with extra characters
      # following the expected filename:
      #
@@ -1229,42 +1232,42 @@ myQP <- function(queryString)
      #
      # check for that, cleanup the string, then see if the file can be found
 
-   ampersand.loc <- as.integer(regexpr("&", queryString, fixed=TRUE))
-   #printf("ampersand.loc: %d", ampersand.loc)
+   ampersand.loc <- as.integer(regexpr("&", queryString, fixed = TRUE))
+   # printf("ampersand.loc: %d", ampersand.loc)
 
-   if(ampersand.loc > 0){
+   if (ampersand.loc > 0) {
       queryString <- substring(queryString, 1, ampersand.loc - 1);
       }
 
-   questionMark.loc <- as.integer(regexpr("?", queryString, fixed=TRUE));
-   #printf("questionMark.loc: %d", questionMark.loc)
+   questionMark.loc <- as.integer(regexpr("?", queryString, fixed = TRUE));
+   # printf("questionMark.loc: %d", questionMark.loc)
 
-   if(questionMark.loc == 1)
+   if (questionMark.loc == 1)
       queryString <- substring(queryString, 2, nchar(queryString))
 
    filename <- queryString;
 
-   if(!file.exists(filename))
-      return(list(contentType="text/html", body=sprintf("file not found: %s", filename)))
+   if (!file.exists(filename))
+      return(list(contentType = "text/html", body = sprintf("file not found: %s", filename)))
 
-   file.extension <- strsplit(basename(filename), ".", fixed=TRUE)[[1]][2]
+   file.extension <- strsplit(basename(filename), ".", fixed = TRUE)[[1]][2]
 
-   if(file.extension == "png"){
-      rawVector <- readBin(filename, raw(), n=file.size(filename))
-      return(list(contentType="image/png", body=rawVector))
+   if (file.extension == "png") {
+      rawVector <- readBin(filename, raw(), n = file.size(filename))
+      return(list(contentType = "image/png", body = rawVector))
       }
 
-   if(file.extension == "bam"){
-      rawVector <- readBin(filename, raw(), n=file.size(filename))
-      return(list(contentType='application/octet-stream', body=rawVector))
+   if (file.extension == "bam") {
+      rawVector <- readBin(filename, raw(), n = file.size(filename))
+      return(list(contentType = 'application/octet-stream', body = rawVector))
       }
 
       # reconstitute linefeeds though collapsing file into one string, so json
       # structure is intact, and any "//" comment tokens only affect one line
 
-   text <- paste(scan(filename, what=character(0), sep="\n", quiet=TRUE), collapse="\n")
+   text <- paste(scan(filename, what = character(0), sep = "\n", quiet = TRUE), collapse = "\n")
 
-   return(list(contentType="text/html", body=text));
+   return(list(contentType = "text/html", body = text));
 
 } # myQP
 #----------------------------------------------------------------------------------------------------
@@ -1272,10 +1275,10 @@ myQP <- function(queryString)
 {
     chromLocString.orig <- chromLocString
     chromLocString <- gsub(",", "", chromLocString);
-    tokens.0 <- strsplit(chromLocString, ":", fixed=TRUE)[[1]]
+    tokens.0 <- strsplit(chromLocString, ":", fixed = TRUE)[[1]]
     stopifnot(length(tokens.0) == 2)
     chrom <- tokens.0[1]
-    if(!grepl("chr", chrom))
+    if (!grepl("chr", chrom))
         chrom <- sprintf("chr%s", chrom)
 
     tokens.1 <- strsplit(tokens.0[2], "-")[[1]]
@@ -1284,8 +1287,7 @@ myQP <- function(queryString)
     end <- as.integer(tokens.1[2])
     width <- 1 + end - start
 
-    return(list(chrom=chrom, start=start, end=end, width=width, string=chromLocString.orig))
+    return(list(chrom = chrom, start = start, end = end, width = width, string = chromLocString.orig))
 
 } # .parseChromLocString
-#------------------------------------------------------------------------------------------------------------------------
-
+#-----------------------------------------------------------------------------------------------------------------------

--- a/vignettes/v00.basicIntro.Rmd
+++ b/vignettes/v00.basicIntro.Rmd
@@ -17,11 +17,11 @@ vignette: >
 
 
 ```{r setup, include = FALSE}
-options(width=120)
+options(width = 120)
 knitr::opts_chunk$set(
    collapse = TRUE,
-   eval=interactive(),
-   echo=TRUE,
+   eval = interactive(),
+   echo = TRUE,
    comment = "#>"
 )
 ```
@@ -83,10 +83,10 @@ showGenomicRegion(igv, "MYC")
 ```{r simple data.frame,  results='hide'}
 loc <- getGenomicRegion(igv)
 
-tbl.bed <- data.frame(chrom=loc$chrom, start=loc$start + 2000, end=loc$end-2000,
-                      name="simple.example", stringsAsFactors=FALSE)
+tbl.bed <- data.frame(chrom = loc$chrom, start = loc$start + 2000, end = loc$end - 2000,
+                      name = "simple.example", stringsAsFactors = FALSE)
 
-track <- DataFrameAnnotationTrack("simple bed", tbl.bed, color="random")
+track <- DataFrameAnnotationTrack("simple bed", tbl.bed, color = "random")
 displayTrack(igv, track)
 ```
 
@@ -95,32 +95,30 @@ displayTrack(igv, track)
 ```{r bedgraph-like data.frame,  results='hide'}
 loc <- getGenomicRegion(igv)
 size <- with(loc, 1 + end - start)
-starts <- seq(loc$start, loc$end, by=5)
-ends   <- starts + 5
-values <- sample(1:100, size=length(starts), replace=TRUE)
+starts <- seq(loc$start, loc$end, by = 5)
+ends <- starts + 5
+values <- sample(1:100, size = length(starts), replace = TRUE)
 
-tbl.bedGraph <- data.frame(chrom=rep("chr8", length(starts)), start=starts, end=ends,
-                           value=values, stringsAsFactors=FALSE)
+tbl.bedGraph <- data.frame(chrom = rep("chr8", length(starts)), start = starts, end = ends,
+                           value = values, stringsAsFactors = FALSE)
 
-track <- DataFrameQuantitativeTrack("bedGraph", tbl.bedGraph, color="red", autoscale=FALSE,
-                                    min=80, max=100)
+track <- DataFrameQuantitativeTrack("bedGraph", tbl.bedGraph, color = "red", autoscale = FALSE,
+                                    min = 80, max = 100)
 displayTrack(igv, track)
-
 ```
 # Zoom out by direct manipulation of the currently displayed region
 
 ```{r zoom out,  results='hide'}
 loc <- getGenomicRegion(igv)
-half.span <- round((loc$end-loc$start)/2)
+half.span <- round((loc$end - loc$start) / 2)
 
-new.region <- with(loc, sprintf("%s:%d-%d", chrom, start-half.span, end+half.span))
+new.region <- with(loc, sprintf("%s:%d-%d", chrom, start - half.span, end + half.span))
 showGenomicRegion(igv, new.region)
 ```
 
 # Zoom out and by function calls
 
 ```{r zoom out new,  results='hide'}
-
 zoomOut(igv)
 zoomIn(igv)
 ```

--- a/vignettes/v01.stockGenome.Rmd
+++ b/vignettes/v01.stockGenome.Rmd
@@ -17,11 +17,11 @@ vignette: >
 
 
 ```{r setup, include = FALSE}
-options(width=120)
+options(width = 120)
 knitr::opts_chunk$set(
    collapse = TRUE,
-   eval=interactive(),
-   echo=TRUE,
+   eval = interactive(),
+   echo = TRUE,
    comment = "#>"
 )
 ```
@@ -56,7 +56,6 @@ panTro4 panTro5 panTro6 rn6 rn7 sacCer3 susScr11 tair10
 setGenome(igv, "hg38_1Kg")
 showGenomicRegion(igv, "APOE")
 zoomOut(igv)
-
 ```
 
 

--- a/vignettes/v02.customGenome.Rmd
+++ b/vignettes/v02.customGenome.Rmd
@@ -17,11 +17,11 @@ vignette: >
 
 
 ```{r setup, include = FALSE}
-options(width=120)
+options(width = 120)
 knitr::opts_chunk$set(
    collapse = TRUE,
-   eval=interactive(),
-   echo=TRUE,
+   eval = interactive(),
+   echo = TRUE,
    comment = "#>"
 )
 ```
@@ -46,43 +46,40 @@ library(igvR)
 igv <- igvR()
 setBrowserWindowTitle(igv, "hg38 explicit")
 setCustomGenome(igv,
-                id="hg38",
-                genomeName="Human (GRCh38/hg38)",
-                fastaURL="https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa",
-                fastaIndexURL="https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa.fai",
-                cytobandURL="https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/cytoBandIdeo.txt",
-                chromosomeAliasURL=NA,
-                geneAnnotationName="Refseq Genes",
-                geneAnnotationURL="https://s3.amazonaws.com/igv.org.genomes/hg38/refGene.txt.gz",
-                geneAnnotationTrackHeight=500,
-                geneAnnotationTrackColor="darkBlue",
-                initialLocus="chr5:88,621,308-89,001,037",
-                visibilityWindow=5000000)
-
+                id = "hg38",
+                genomeName = "Human (GRCh38/hg38)",
+                fastaURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa",
+                fastaIndexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa.fai",
+                cytobandURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/cytoBandIdeo.txt",
+                chromosomeAliasURL = NA,
+                geneAnnotationName = "Refseq Genes",
+                geneAnnotationURL = "https://s3.amazonaws.com/igv.org.genomes/hg38/refGene.txt.gz",
+                geneAnnotationTrackHeight = 500,
+                geneAnnotationTrackColor = "darkBlue",
+                initialLocus = "chr5:88,621,308-89,001,037",
+                visibilityWindow = 5000000)
 ```
 
 # Use the SARS-CoV-2 genome
 
 ```{r eval=FALSE}
-
 base.url <- "https://gladki.pl/igvR/testFiles/sarsGenome"
-fasta.file <- sprintf("%s/%s", base.url,"Sars_cov_2.ASM985889v3.dna.toplevel.fa")
-fastaIndex.file <-  sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.dna.toplevel.fa.fai")
-annotation.file <-  sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.101.gff3")
+fasta.file <- sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.dna.toplevel.fa")
+fastaIndex.file <- sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.dna.toplevel.fa.fai")
+annotation.file <- sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.101.gff3")
 
 Sys.sleep(2)
 
 setCustomGenome(igv,
-                id="Sars_cov_2",
-                genomeName="Sars_cov_2.ASM985889v3",
-                fastaURL=fasta.file,
-                fastaIndexURL=fastaIndex.file,
-                geneAnnotationURL=annotation.file,
-                geneAnnotationName="ASM985889v3",
-                geneAnnotationTrackHeight=500,
-                geneAnnotationTrackColor="darkBlue",
-                visibilityWindow=30000)
-
+                id = "Sars_cov_2",
+                genomeName = "Sars_cov_2.ASM985889v3",
+                fastaURL = fasta.file,
+                fastaIndexURL = fastaIndex.file,
+                geneAnnotationURL = annotation.file,
+                geneAnnotationName = "ASM985889v3",
+                geneAnnotationTrackHeight = 500,
+                geneAnnotationTrackColor = "darkBlue",
+                visibilityWindow = 30000)
 ```
 
 # Configure and run an nginx webserver, with CORS and Byte-Range support

--- a/vignettes/v04.pairedEnd.Rmd
+++ b/vignettes/v04.pairedEnd.Rmd
@@ -17,11 +17,11 @@ vignette: >
 
 
 ```{r setup, include = FALSE}
-options(width=120)
+options(width = 120)
 knitr::opts_chunk$set(
    collapse = TRUE,
-   eval=interactive(),
-   echo=TRUE,
+   eval = interactive(),
+   echo = TRUE,
    comment = "#>"
 )
 ```
@@ -62,16 +62,16 @@ library(igvR)
 igv <- igvR()
 setBrowserWindowTitle(igv, "Paired-end demo")
 setGenome(igv, "hg38")
-tbl.bedpe <- data.frame(chrom1=c("2","2"),
-                        start1=c(105780000, 105575000),
-                        end1=c(105790000, 105600000),
-                        chrom2=c("2","2"),
-                        start2=c(105890000, 106075000),
-                        end2=c(105900000, 106100000),
-                        stringsAsFactors=FALSE)
+tbl.bedpe <- data.frame(chrom1 = c("2", "2"),
+                        start1 = c(105780000, 105575000),
+                        end1 = c(105790000, 105600000),
+                        chrom2 = c("2", "2"),
+                        start2 = c(105890000, 106075000),
+                        end2 = c(105900000, 106100000),
+                        stringsAsFactors = FALSE)
 
   # construct a "region of interest" (roi) string from tbl.bedpe
-  # this is where our two features are found. 
+  # this is where our two features are found.
 
 shoulder <- 300000
 roi <- sprintf("%s:%d-%d", tbl.bedpe$chrom1[1],

--- a/vignettes/v05.ucscTableBrowser.Rmd
+++ b/vignettes/v05.ucscTableBrowser.Rmd
@@ -17,11 +17,11 @@ vignette: >
 
 
 ```{r setup, include = FALSE}
-options(width=120)
+options(width = 120)
 knitr::opts_chunk$set(
    collapse = TRUE,
-   eval=interactive(),
-   echo=TRUE,
+   eval = interactive(),
+   echo = TRUE,
    comment = "#>"
 )
 ```
@@ -119,7 +119,7 @@ knitr::include_graphics("images/ucscTableBrowser-getOutput.png")
 # Read the data into R
 
 ```{r eval=FALSE}
-tbl <- read.table("~/drop/k562-h3k4me3-gata2.tsv", sep="\t", skip=1, as.is=TRUE, fill=TRUE)
+tbl <- read.table("~/drop/k562-h3k4me3-gata2.tsv", sep = "\t", skip = 1, as.is = TRUE, fill = TRUE)
 colnames(tbl) <- c("chrom", "start", "end", "score")
 ```
 Make sure the column classes are as expected:
@@ -144,7 +144,7 @@ $score
 # Create and Display a Quantitative Track
 
 ```{r eval=FALSE}
-track <- DataFrameQuantitativeTrack("H3K4Me3 K562", tbl, autoscale=TRUE, color="darkGreen")
+track <- DataFrameQuantitativeTrack("H3K4Me3 K562", tbl, autoscale = TRUE, color = "darkGreen")
 displayTrack(igv, track)
 ```
 

--- a/vignettes/v06.annotationHub.Rmd
+++ b/vignettes/v06.annotationHub.Rmd
@@ -17,11 +17,11 @@ vignette: >
 
 
 ```{r setup, include = FALSE}
-options(width=120)
+options(width = 120)
 knitr::opts_chunk$set(
    collapse = TRUE,
-   eval=interactive(),
-   echo=TRUE,
+   eval = interactive(),
+   echo = TRUE,
    comment = "#>"
 )
 ```
@@ -54,7 +54,7 @@ igv <- igvR()
 setBrowserWindowTitle(igv, "H3K27ac GATA2")
 setGenome(igv, "hg19")
 showGenomicRegion(igv, "GATA2")
-for(i in 1:4) zoomOut(igv)
+for (i in 1:4) zoomOut(igv)
 ```
 
 ```{r, eval=TRUE, echo=FALSE, out.width="95%"}
@@ -66,7 +66,7 @@ knitr::include_graphics("images/annotationHub-01.png")
 ```{r eval=FALSE}
 aHub <- AnnotationHub()
 query.terms <- c("H3K27Ac", "k562")
-length(query(aHub, query.terms))  # found 7
+length(query(aHub, query.terms)) # found 7
 h3k27ac.entries <- query(aHub, query.terms)
 ```
 The available data, key and title:
@@ -102,7 +102,7 @@ only the 252 kb region in which we are interested.
 
 ```{r eval=FALSE}
 roi <- getGenomicRegion(igv)
-gr.broadpeak <- x.broadPeak[seqnames(x.broadpeak)==roi$chrom &
+gr.broadpeak <- x.broadPeak[seqnames(x.broadpeak) == roi$chrom &
                             start(x.broadpeak) > roi$start &
                             end(x.broadpeak) < roi$end]
 ```
@@ -113,7 +113,7 @@ That column is used as the magnitudes the track will display.
 names(mcols(gr.broadpeak))
   #  "name"        "score"       "signalValue" "pValue"      "qValue"
 mcols(gr.broadpeak) <- gr.broadpeak$score
-track <- GRangesQuantitativeTrack("h3k27ac bp", gr.broadpeak, autoscale=TRUE, color="brown")
+track <- GRangesQuantitativeTrack("h3k27ac bp", gr.broadpeak, autoscale = TRUE, color = "brown")
 displayTrack(igv, track)
 ```
 
@@ -123,13 +123,11 @@ of the large bigWig file.  Note that, as read, there is only one numeric metadat
 so no reduction of mcols is needed.
 
 ```{r eval=FALSE}
-
 file.bigWig <- resource(x.bigWig)[[1]]
-gr.roi <- with(roi, GRanges(seqnames=chrom, IRanges(start, end)))
-gr.bw <- import(file.bigWig, which=gr.roi, format="bigWig")
-track <- GRangesQuantitativeTrack("h3k27ac.bw", gr.bw, autoscale=TRUE, color="gray")
+gr.roi <- with(roi, GRanges(seqnames = chrom, IRanges(start, end)))
+gr.bw <- import(file.bigWig, which = gr.roi, format = "bigWig")
+track <- GRangesQuantitativeTrack("h3k27ac.bw", gr.bw, autoscale = TRUE, color = "gray")
 displayTrack(igv, track)
-
 ```
 
 ```{r, eval=TRUE, echo=FALSE, out.width="95%"}

--- a/vignettes/v07.gwas.Rmd
+++ b/vignettes/v07.gwas.Rmd
@@ -17,11 +17,11 @@ vignette: >
 
 
 ```{r setup, include = FALSE}
-options(width=120)
+options(width = 120)
 knitr::opts_chunk$set(
    collapse = TRUE,
-   eval=interactive(),
-   echo=TRUE,
+   eval = interactive(),
+   echo = TRUE,
    comment = "#>"
 )
 ```
@@ -75,9 +75,9 @@ library(igvR)
 igv <- igvR()
 setBrowserWindowTitle(igv, "AD GWAS")
 setGenome(igv, "hg38")
-tbl.gwas <- read.table(system.file(package="igvR", "extdata", "gwas", "bellenguez.bed"),
-                       sep="\t", as.is=TRUE, header=TRUE, nrow=-1)
-track <- GWASTrack("bellenguuez", tbl.gwas, chrom.col=1, pos.col=2, pval.col=5, trackHeight=80)
+tbl.gwas <- read.table(system.file(package = "igvR", "extdata", "gwas", "bellenguez.bed"),
+                       sep = "\t", as.is = TRUE, header = TRUE, nrow = -1)
+track <- GWASTrack("bellenguuez", tbl.gwas, chrom.col = 1, pos.col = 2, pval.col = 5, trackHeight = 80)
 displayTrack(igv, track)
 ```
 
@@ -136,7 +136,7 @@ Here we create the track and display it:
 
 ```{r eval=FALSE}
 url <- "https://s3.amazonaws.com/igv.org.demo/gwas_sample.tsv.gz"
-track <- GWASUrlTrack("igv sample", url,chrom.col=12, pos.col=13, pval.col=28)
+track <- GWASUrlTrack("igv sample", url, chrom.col = 12, pos.col = 13, pval.col = 28)
 displayTrack(igv, track)
 ```
 First, the whole genome view:

--- a/vignettes/v08.cram.Rmd
+++ b/vignettes/v08.cram.Rmd
@@ -16,11 +16,11 @@ vignette: >
 </style>
 
 ```{r setup, include = FALSE}
-options(width=120)
+options(width = 120)
 knitr::opts_chunk$set(
    collapse = TRUE,
-   eval=interactive(),
-   echo=TRUE,
+   eval = interactive(),
+   echo = TRUE,
    comment = "#>"
 )
 ```


### PR DESCRIPTION
## Summary

- Fixed **1752 linting violations** across all `R/` source files and `vignettes/`
- **infix_spaces**: applied `styler` with `scope="spaces"` to all R/ files
- **line_length**: manually wrapped all lines exceeding 120 characters (gDRstyle limit)
- Conflict resolved: `UCSCBedGraphQuantitativeTrack.R` now uses `is()` (from #42) with proper spacing (from this branch)

## Test plan

- [ ] `gDRstyle::checkPackage` with `skip_lint = FALSE` reports 0 linting violations
- [ ] CI passes on all platforms